### PR TITLE
Custom read size for read_size_helper

### DIFF
--- a/include/boost/asio/basic_streambuf.hpp
+++ b/include/boost/asio/basic_streambuf.hpp
@@ -32,6 +32,10 @@
 
 #include <boost/asio/detail/push_options.hpp>
 
+#ifndef ASIO_PREFERRED_READ_SIZE
+#define ASIO_PREFERRED_READ_SIZE 512
+#endif
+
 namespace boost {
 namespace asio {
 
@@ -346,7 +350,7 @@ private:
       basic_streambuf& sb, std::size_t max_size)
   {
     return std::min<std::size_t>(
-        std::max<std::size_t>(512, sb.buffer_.capacity() - sb.size()),
+		std::max<std::size_t>(ASIO_PREFERRED_READ_SIZE, sb.buffer_.capacity() - sb.size()),
         std::min<std::size_t>(max_size, sb.max_size() - sb.size()));
   }
 };
@@ -357,7 +361,7 @@ template <typename Allocator>
 inline std::size_t read_size_helper(
     basic_streambuf<Allocator>& sb, std::size_t max_size)
 {
-  return std::min<std::size_t>(512,
+  return std::min<std::size_t>(ASIO_PREFERRED_READ_SIZE,
       std::min<std::size_t>(max_size, sb.max_size() - sb.size()));
 }
 

--- a/include/boost/asio/basic_streambuf.hpp
+++ b/include/boost/asio/basic_streambuf.hpp
@@ -33,7 +33,7 @@
 #include <boost/asio/detail/push_options.hpp>
 
 #ifndef ASIO_PREFERRED_READ_SIZE
-#define ASIO_PREFERRED_READ_SIZE 512
+# define ASIO_PREFERRED_READ_SIZE 512
 #endif
 
 namespace boost {

--- a/include/boost/asio/impl/connect.hpp
+++ b/include/boost/asio/impl/connect.hpp
@@ -118,7 +118,6 @@ Iterator connect(basic_socket<Protocol, SocketService>& s,
     iter = connect_condition(ec, iter);
     if (iter != end)
     {
-      s.close(ec);
       s.connect(*iter, ec);
       if (!ec)
         return iter;
@@ -223,7 +222,6 @@ namespace detail
 
           if (iter_ != end_)
           {
-            socket_.close(ec);
             socket_.async_connect(*iter_,
                 BOOST_ASIO_MOVE_CAST(connect_op)(*this));
             return;


### PR DESCRIPTION
Sometimes, we need custom read size, avoid excessive circulation. 