### PR TITLE
test_main symbol was undefined. Added a fake definition to compensate.

### DIFF
--- a/test/unit_test.hpp
+++ b/test/unit_test.hpp
@@ -17,6 +17,13 @@
 # include <stdlib.h> // Needed for lrand48.
 #endif // defined(__sun)
 
+#ifdef _AIX
+// AIX needs this symbol defined in asio, even if it doesn't do anything.
+int test_main(int, char**)
+{
+}
+#endif
+
 #if defined(__BORLANDC__)
 
 // Prevent use of intrinsic for strcmp.


### PR DESCRIPTION
The symbol test_main was left undefined for every single one of the asio tests. As a result I would get the following error over and over:

ld: 0711-317 ERROR: Undefined symbol: .test_main(int, char**)

The weird thing is that the tests did not appear to be using this symbol at all, yet it was still preserved. To compensate I added an empty definition of test_main. This allowed all of the tests in the suite to run. Most of the tests passed except for two, but for unrelated issues that I still need to look at.

It is possible that the semantics of the AIX linker and the way that GCC interacts with the linker are causing extra symbols to be preserved. There might need to be in the future more work that needs to be done for either, but for now I think this is a good solution.
