### PR TITLE
Fixed compilation failures caused by conflicts with Boost.Range.

### DIFF
--- a/include/boost/asio/basic_socket_streambuf.hpp
+++ b/include/boost/asio/basic_socket_streambuf.hpp
@@ -310,7 +310,7 @@ protected:
 
       io_handler handler = { this };
       this->get_service().async_receive(this->get_implementation(),
-          boost::asio::buffer(boost::asio::buffer(get_buffer_) + putback_max),
+          boost::asio::buffer(boost::asio::buffer(get_buffer_) + static_cast< std::size_t >(putback_max)),
           0, handler);
 
       ec_ = boost::asio::error::would_block;
@@ -320,8 +320,8 @@ protected:
       if (ec_)
         return traits_type::eof();
 
-      setg(&get_buffer_[0], &get_buffer_[0] + putback_max,
-          &get_buffer_[0] + putback_max + bytes_transferred_);
+      setg(&get_buffer_[0], &get_buffer_[0] + static_cast< std::size_t >(putback_max),
+          &get_buffer_[0] + static_cast< std::size_t >(putback_max) + bytes_transferred_);
       return traits_type::to_int_type(*gptr());
     }
     else
@@ -433,8 +433,8 @@ private:
   void init_buffers()
   {
     setg(&get_buffer_[0],
-        &get_buffer_[0] + putback_max,
-        &get_buffer_[0] + putback_max);
+        &get_buffer_[0] + static_cast< std::size_t >(putback_max),
+        &get_buffer_[0] + static_cast< std::size_t >(putback_max));
     if (unbuffered_)
       setp(0, 0);
     else
@@ -543,8 +543,11 @@ private:
     }
   }
 
-  enum { putback_max = 8 };
-  enum { buffer_size = 512 };
+  enum _
+  {
+    putback_max = 8,
+    buffer_size = 512
+  };
   boost::asio::detail::array<char, buffer_size> get_buffer_;
   boost::asio::detail::array<char, buffer_size> put_buffer_;
   bool unbuffered_;

--- a/include/boost/asio/detail/buffer_sequence_adapter.hpp
+++ b/include/boost/asio/detail/buffer_sequence_adapter.hpp
@@ -31,7 +31,7 @@ class buffer_sequence_adapter_base
 protected:
 #if defined(BOOST_ASIO_WINDOWS_RUNTIME)
   // The maximum number of buffers to support in a single operation.
-  enum { max_buffers = 1 };
+  enum _ { max_buffers = 1 };
 
   typedef Windows::Storage::Streams::IBuffer^ native_buffer_type;
 
@@ -44,7 +44,7 @@ protected:
       const boost::asio::const_buffer& buffer);
 #elif defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
   // The maximum number of buffers to support in a single operation.
-  enum { max_buffers = 64 < max_iov_len ? 64 : max_iov_len };
+  enum _ { max_buffers = 64 < max_iov_len ? 64 : max_iov_len };
 
   typedef WSABUF native_buffer_type;
 
@@ -63,7 +63,7 @@ protected:
   }
 #else // defined(BOOST_ASIO_WINDOWS) || defined(__CYGWIN__)
   // The maximum number of buffers to support in a single operation.
-  enum { max_buffers = 64 < max_iov_len ? 64 : max_iov_len };
+  enum _ { max_buffers = 64 < max_iov_len ? 64 : max_iov_len };
 
   typedef iovec native_buffer_type;
 
@@ -106,7 +106,7 @@ public:
   {
     typename Buffers::const_iterator iter = buffer_sequence.begin();
     typename Buffers::const_iterator end = buffer_sequence.end();
-    for (; iter != end && count_ < max_buffers; ++iter, ++count_)
+    for (; iter != end && count_ < static_cast< std::size_t >(max_buffers); ++iter, ++count_)
     {
       Buffer buffer(*iter);
       init_native_buffer(buffers_[count_], buffer);
@@ -134,7 +134,7 @@ public:
     typename Buffers::const_iterator iter = buffer_sequence.begin();
     typename Buffers::const_iterator end = buffer_sequence.end();
     std::size_t i = 0;
-    for (; iter != end && i < max_buffers; ++iter, ++i)
+    for (; iter != end && i < static_cast< std::size_t >(max_buffers); ++iter, ++i)
       if (boost::asio::buffer_size(Buffer(*iter)) > 0)
         return false;
     return true;

--- a/include/boost/asio/detail/impl/win_tss_ptr.ipp
+++ b/include/boost/asio/detail/impl/win_tss_ptr.ipp
@@ -32,9 +32,9 @@ namespace detail {
 DWORD win_tss_ptr_create()
 {
 #if defined(UNDER_CE)
-  enum { out_of_indexes = 0xFFFFFFFF };
+  const DWORD out_of_indexes = 0xFFFFFFFF;
 #else
-  enum { out_of_indexes = TLS_OUT_OF_INDEXES };
+  const DWORD out_of_indexes = TLS_OUT_OF_INDEXES;
 #endif
 
   DWORD tss_key = ::TlsAlloc();

--- a/include/boost/asio/ssl/old/detail/openssl_stream_service.hpp
+++ b/include/boost/asio/ssl/old/detail/openssl_stream_service.hpp
@@ -46,7 +46,7 @@ class openssl_stream_service
   : public boost::asio::detail::service_base<openssl_stream_service>
 {
 private:
-  enum { max_buffer_size = INT_MAX };
+  enum _ { max_buffer_size = INT_MAX };
 
   //Base handler for asyncrhonous operations
   template <typename Stream>
@@ -338,8 +338,8 @@ public:
           boost::asio::const_buffer, Const_Buffers>::first(buffers);
 
       std::size_t buffer_size = boost::asio::buffer_size(buffer);
-      if (buffer_size > max_buffer_size)
-        buffer_size = max_buffer_size;
+      if (buffer_size > static_cast< std::size_t >(max_buffer_size))
+        buffer_size = static_cast< std::size_t >(max_buffer_size);
       else if (buffer_size == 0)
       {
         ec = boost::system::error_code();
@@ -381,8 +381,8 @@ public:
         boost::asio::const_buffer, Const_Buffers>::first(buffers);
 
     std::size_t buffer_size = boost::asio::buffer_size(buffer);
-    if (buffer_size > max_buffer_size)
-      buffer_size = max_buffer_size;
+    if (buffer_size > static_cast< std::size_t >(max_buffer_size))
+      buffer_size = static_cast< std::size_t >(max_buffer_size);
     else if (buffer_size == 0)
     {
       get_io_service().post(boost::asio::detail::bind_handler(
@@ -431,8 +431,8 @@ public:
           boost::asio::mutable_buffer, Mutable_Buffers>::first(buffers);
 
       std::size_t buffer_size = boost::asio::buffer_size(buffer);
-      if (buffer_size > max_buffer_size)
-        buffer_size = max_buffer_size;
+      if (buffer_size > static_cast< std::size_t >(max_buffer_size))
+        buffer_size = static_cast< std::size_t >(max_buffer_size);
       else if (buffer_size == 0)
       {
         ec = boost::system::error_code();
@@ -474,8 +474,8 @@ public:
         boost::asio::mutable_buffer, Mutable_Buffers>::first(buffers);
 
     std::size_t buffer_size = boost::asio::buffer_size(buffer);
-    if (buffer_size > max_buffer_size)
-      buffer_size = max_buffer_size;
+    if (buffer_size > static_cast< std::size_t >(max_buffer_size))
+      buffer_size = static_cast< std::size_t >(max_buffer_size);
     else if (buffer_size == 0)
     {
       get_io_service().post(boost::asio::detail::bind_handler(


### PR DESCRIPTION
Added names to some enum types to avoid compilation failures with gcc 4.4 caused by operators defined by Boost.Range in namespace boost. The operators fail to compile because they attempt to instantiate a template with the anonymous enum type in its parameters.

Additionally, added explicit type casts to the enum values to avoid any further possible ambiguities.
