### PR TITLE
Only write to locked_ while we hold the lock

### DIFF
--- a/include/boost/asio/detail/scoped_lock.hpp
+++ b/include/boost/asio/detail/scoped_lock.hpp
@@ -69,8 +69,8 @@ public:
   {
     if (locked_)
     {
-      mutex_.unlock();
       locked_ = false;
+      mutex_.unlock();
     }
   }
 


### PR DESCRIPTION
To avoid race conditions, locked_ should be set to false before we release the lock.
