### PR TITLE
Initialize member variables in constructor

### DIFF
--- a/include/boost/asio/detail/impl/epoll_reactor.ipp
+++ b/include/boost/asio/detail/impl/epoll_reactor.ipp
@@ -600,8 +600,14 @@ struct epoll_reactor::perform_io_cleanup_on_block_exit
   operation* first_op_;
 };
 
-epoll_reactor::descriptor_state::descriptor_state()
-  : operation(&epoll_reactor::descriptor_state::do_complete)
+epoll_reactor::descriptor_state::descriptor_state() :
+operation(&epoll_reactor::descriptor_state::do_complete),
+next_(),
+prev_(),
+reactor_(),
+descriptor_(),
+registered_events_(),
+shutdown_()
 {
 }
 


### PR DESCRIPTION
Default value-initialize these member variables of the object, as they are not themselves and objects and thus can not have default constructors called automatically to initialize them.
This defect was uncovered by Coverity and has Coverity issue id CID14974.
