### PR TITLE
Don't release lock until after signaling condition.

### DIFF
--- a/include/boost/asio/detail/posix_event.hpp
+++ b/include/boost/asio/detail/posix_event.hpp
@@ -66,9 +66,9 @@ public:
     BOOST_ASIO_ASSERT(lock.locked());
     state_ |= 1;
     bool have_waiters = (state_ > 1);
-    lock.unlock();
     if (have_waiters)
       ::pthread_cond_signal(&cond_); // Ignore EINVAL.
+    lock.unlock();
   }
 
   // If there's a waiter, unlock the mutex and signal it.
@@ -79,8 +79,8 @@ public:
     state_ |= 1;
     if (state_ > 1)
     {
-      lock.unlock();
       ::pthread_cond_signal(&cond_); // Ignore EINVAL.
+      lock.unlock();
       return true;
     }
     return false;


### PR DESCRIPTION
This change addresses a reproducible crash that we encountered. The details of the fix are described in the linked bug report.

Original description (from bstrong):

  This fixes a race in task_io_service where the event_object is
  protected by the lock, and releasing the lock allows it to be deleted
  before the condition is signaled.

See  also: https://svn.boost.org/trac/boost/ticket/10213#comment:2
