### PR TITLE
Fix rare race condition.

### DIFF
--- a/include/boost/asio/detail/impl/epoll_reactor.ipp
+++ b/include/boost/asio/detail/impl/epoll_reactor.ipp
@@ -333,10 +333,9 @@ void epoll_reactor::deregister_descriptor(socket_type descriptor,
     descriptor_data->descriptor_ = -1;
     descriptor_data->shutdown_ = true;
 
-    descriptor_lock.unlock();
-
     free_descriptor_state(descriptor_data);
     descriptor_data = 0;
+    descriptor_lock.unlock();
 
     io_service_.post_deferred_completions(ops);
   }
@@ -361,8 +360,6 @@ void epoll_reactor::deregister_internal_descriptor(socket_type descriptor,
 
     descriptor_data->descriptor_ = -1;
     descriptor_data->shutdown_ = true;
-
-    descriptor_lock.unlock();
 
     free_descriptor_state(descriptor_data);
     descriptor_data = 0;


### PR DESCRIPTION
descriptor_data->mutex_ should be unlocked after descriptor data state is freed up as free_descriptor_state uses another lock to do its operation. While doing free, if some other thread get LOCK 1 i.e descriptor_data->mutex_, it may cause crash in rare condition , when LOCK2 i.e registered_descriptors_mutex_ frees some relevant member variable. In case of deregister_internal_descriptor, no need to unlock as scoped lock will get unlock, once it gets out of scope.
