### PR TITLE
Throw error on fcntl fail

### DIFF
--- a/include/boost/asio/detail/impl/epoll_reactor.ipp
+++ b/include/boost/asio/detail/impl/epoll_reactor.ipp
@@ -470,7 +470,15 @@ int epoll_reactor::do_epoll_create()
   {
     fd = epoll_create(epoll_size);
     if (fd != -1)
-      ::fcntl(fd, F_SETFD, FD_CLOEXEC);
+    {
+      int status = ::fcntl(fd, F_SETFD, FD_CLOEXEC);
+      if (status == -1)
+      {
+        boost::system::error_code ec(errno,
+          boost::asio::error::get_system_category());
+        boost::asio::detail::throw_error(ec, "epoll");
+      }
+    }
   }
 
   if (fd == -1)
@@ -497,7 +505,15 @@ int epoll_reactor::do_timerfd_create()
   {
     fd = timerfd_create(CLOCK_MONOTONIC, 0);
     if (fd != -1)
-      ::fcntl(fd, F_SETFD, FD_CLOEXEC);
+    {
+      int status = ::fcntl(fd, F_SETFD, FD_CLOEXEC);
+      if (status == -1)
+      {
+        boost::system::error_code ec(errno,
+          boost::asio::error::get_system_category());
+        boost::asio::detail::throw_error(ec, "epoll");
+      }
+    }
   }
 
   return fd;

--- a/include/boost/asio/detail/impl/eventfd_select_interrupter.ipp
+++ b/include/boost/asio/detail/impl/eventfd_select_interrupter.ipp
@@ -47,11 +47,24 @@ eventfd_select_interrupter::eventfd_select_interrupter()
 void eventfd_select_interrupter::open_descriptors()
 {
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+  int status;
   write_descriptor_ = read_descriptor_ = syscall(__NR_eventfd, 0);
   if (read_descriptor_ != -1)
   {
-    ::fcntl(read_descriptor_, F_SETFL, O_NONBLOCK);
-    ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
+    status = ::fcntl(read_descriptor_, F_SETFL, O_NONBLOCK);
+    if (status == -1)
+    {
+      boost::system::error_code ec(errno,
+        boost::asio::error::get_system_category());
+      boost::asio::detail::throw_error(ec, "eventfd_select_interrupter");
+    }
+    status = ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
+    if (status == -1)
+    {
+      boost::system::error_code ec(errno,
+        boost::asio::error::get_system_category());
+      boost::asio::detail::throw_error(ec, "eventfd_select_interrupter");
+    }
   }
 #else // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
 # if defined(EFD_CLOEXEC) && defined(EFD_NONBLOCK)
@@ -66,8 +79,20 @@ void eventfd_select_interrupter::open_descriptors()
     write_descriptor_ = read_descriptor_ = ::eventfd(0, 0);
     if (read_descriptor_ != -1)
     {
-      ::fcntl(read_descriptor_, F_SETFL, O_NONBLOCK);
-      ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
+      status = ::fcntl(read_descriptor_, F_SETFL, O_NONBLOCK);
+      if (status == -1)
+      {
+        boost::system::error_code ec(errno,
+          boost::asio::error::get_system_category());
+        boost::asio::detail::throw_error(ec, "eventfd_select_interrupter");
+      }
+      status = ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
+      if (status == -1)
+      {
+        boost::system::error_code ec(errno,
+          boost::asio::error::get_system_category());
+        boost::asio::detail::throw_error(ec, "eventfd_select_interrupter");
+      }
     }
   }
 #endif // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
@@ -78,11 +103,35 @@ void eventfd_select_interrupter::open_descriptors()
     if (pipe(pipe_fds) == 0)
     {
       read_descriptor_ = pipe_fds[0];
-      ::fcntl(read_descriptor_, F_SETFL, O_NONBLOCK);
-      ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
+      status = ::fcntl(read_descriptor_, F_SETFL, O_NONBLOCK);
+      if (status == -1)
+      {
+        boost::system::error_code ec(errno,
+          boost::asio::error::get_system_category());
+        boost::asio::detail::throw_error(ec, "eventfd_select_interrupter");
+      }
+      status = ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
+      if (status == -1)
+      {
+        boost::system::error_code ec(errno,
+          boost::asio::error::get_system_category());
+        boost::asio::detail::throw_error(ec, "eventfd_select_interrupter");
+      }
       write_descriptor_ = pipe_fds[1];
-      ::fcntl(write_descriptor_, F_SETFL, O_NONBLOCK);
-      ::fcntl(write_descriptor_, F_SETFD, FD_CLOEXEC);
+      status = ::fcntl(write_descriptor_, F_SETFL, O_NONBLOCK);
+      if (status == -1)
+      {
+        boost::system::error_code ec(errno,
+          boost::asio::error::get_system_category());
+        boost::asio::detail::throw_error(ec, "eventfd_select_interrupter");
+      }
+      status = ::fcntl(write_descriptor_, F_SETFD, FD_CLOEXEC);
+      if (status == -1)
+      {
+        boost::system::error_code ec(errno,
+          boost::asio::error::get_system_category());
+        boost::asio::detail::throw_error(ec, "eventfd_select_interrupter");
+      }
     }
     else
     {

--- a/include/boost/asio/detail/impl/signal_set_service.ipp
+++ b/include/boost/asio/detail/impl/signal_set_service.ipp
@@ -575,14 +575,39 @@ void signal_set_service::open_descriptors()
   if (::pipe(pipe_fds) == 0)
   {
     state->read_descriptor_ = pipe_fds[0];
-    ::fcntl(state->read_descriptor_, F_SETFL, O_NONBLOCK);
+    int status;
+    status = ::fcntl(state->read_descriptor_, F_SETFL, O_NONBLOCK);
+    if (status == -1)
+    {
+      boost::system::error_code ec(errno,
+        boost::asio::error::get_system_category());
+      boost::asio::detail::throw_error(ec, "signal_set_service pipe");
+    }
 
     state->write_descriptor_ = pipe_fds[1];
-    ::fcntl(state->write_descriptor_, F_SETFL, O_NONBLOCK);
+    status = ::fcntl(state->write_descriptor_, F_SETFL, O_NONBLOCK);
+    if (status == -1)
+    {
+      boost::system::error_code ec(errno,
+        boost::asio::error::get_system_category());
+      boost::asio::detail::throw_error(ec, "signal_set_service pipe");
+    }
 
 #if defined(FD_CLOEXEC)
-    ::fcntl(state->read_descriptor_, F_SETFD, FD_CLOEXEC);
-    ::fcntl(state->write_descriptor_, F_SETFD, FD_CLOEXEC);
+    status = ::fcntl(state->read_descriptor_, F_SETFD, FD_CLOEXEC);
+    if (status == -1)
+    {
+      boost::system::error_code ec(errno,
+        boost::asio::error::get_system_category());
+      boost::asio::detail::throw_error(ec, "signal_set_service pipe");
+    }
+    status = ::fcntl(state->write_descriptor_, F_SETFD, FD_CLOEXEC);
+    if (status == -1)
+    {
+      boost::system::error_code ec(errno,
+        boost::asio::error::get_system_category());
+      boost::asio::detail::throw_error(ec, "signal_set_service pipe");
+    }
 #endif // defined(FD_CLOEXEC)
   }
   else


### PR DESCRIPTION
If fcntl fails, it ought not fail silently. This issue is related to CID14947, CID14946, CID14949, and CID14948 in Coverity, and was uncovered by Coverity.
