### PR TITLE
Disable __thread keyword for android-clang

### DIFF
--- a/include/boost/asio/detail/config.hpp
+++ b/include/boost/asio/detail/config.hpp
@@ -939,7 +939,7 @@
 # if defined(__linux__)
 #  if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 #   if ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3)
-#    if !defined(__INTEL_COMPILER) && !defined(__ICL)
+#    if !defined(__INTEL_COMPILER) && !defined(__ICL) && !(defined(__clang__) && defined(__ANDROID__))
 #     define BOOST_ASIO_HAS_THREAD_KEYWORD_EXTENSION 1
 #     define BOOST_ASIO_THREAD_KEYWORD __thread
 #    elif defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1100)


### PR DESCRIPTION
Clang on Android don't support __thread properly since it
require some support from runtime, and Android don't provide it.
Look at https://tracker.crystax.net/issues/912 for details.