### PR TITLE
Support the macro `OPENSSL_NO_SSL3`

### DIFF
--- a/include/boost/asio/ssl/impl/context.ipp
+++ b/include/boost/asio/ssl/impl/context.ipp
@@ -89,6 +89,14 @@ context::context(context::method m)
     handle_ = ::SSL_CTX_new(::SSLv2_server_method());
     break;
 #endif // defined(OPENSSL_NO_SSL2)
+#if defined(OPENSSL_NO_SSL3)
+  case context::sslv3:
+  case context::sslv3_client:
+  case context::sslv3_server:
+    boost::asio::detail::throw_error(
+        boost::asio::error::invalid_argument, "context");
+    break;
+#else // defined(OPENSSL_NO_SSL3)
   case context::sslv3:
     handle_ = ::SSL_CTX_new(::SSLv3_method());
     break;
@@ -98,6 +106,7 @@ context::context(context::method m)
   case context::sslv3_server:
     handle_ = ::SSL_CTX_new(::SSLv3_server_method());
     break;
+#endif // defined(OPENSSL_NO_SSL3)
   case context::tlsv1:
     handle_ = ::SSL_CTX_new(::TLSv1_method());
     break;


### PR DESCRIPTION
In LibreSSL, SSLv3 was removed 1 week ago. I was need supporting `OPENSSL_NO_SSL3` macro because I use Boost.Asio with the latest libressl.

Ref.: https://github.com/libressl-portable/openbsd/commit/b038833f6e0ec4ab42792cb01c16303a183fb98c
