### PR TITLE
Improve windows timer precision when dealing with duration < 1ms with a CPU trade-off

### DIFF
--- a/include/boost/asio/detail/impl/win_iocp_io_service.ipp
+++ b/include/boost/asio/detail/impl/win_iocp_io_service.ipp
@@ -520,6 +520,12 @@ void win_iocp_io_service::update_timeout()
     long timeout_usec = timer_queues_.wait_duration_usec(max_timeout_usec);
     if (timeout_usec < max_timeout_usec)
     {
+#if defined(BOOST_ASIO_ENABLE_CPU_TIMER_TRADE_OFF)
+      if (timeout_usec < 1000)
+      {
+        timeout_usec = -1;
+      }
+#endif
       LARGE_INTEGER timeout;
       timeout.QuadPart = -timeout_usec;
       timeout.QuadPart *= 10;


### PR DESCRIPTION
Hi Chris,

While developing our [boost.asio stream socket based on UDT protocol](https://github.com/securesocketfunneling/udt), we encountered performance issues using asio timers on Windows.
[UDT protocol](http://udt.sourceforge.net/) adjusts numerous critical variables for its internal dataflow  and bandwidth management using micro timing events.

The proposed patch improves asio timer precision when dealing with short wait duration (< 1 ms) with a CPU trade-off, activable using macro definition "BOOST_ASIO_ENABLE_CPU_TIMER_TRADE_OFF".

On UDT implementation, this patch leads to a dramatically increased bandwidth (from 10-15Mbit/s up to 300Mbit/s approx).
Without it, boost asio's timer could not be used when "high" precision is required.

What do you think about it ?

Please, [find enclosed](https://github.com/securesocketfunneling/udt/blob/develop/src/timer_benchmark/main.cpp) a test program that can be used to get an idea of patch's impact on sub-millisecond timers.

Here are some results we get :

#### Without patch : 
```
Number of samples    : 10000
Expected wait (usec) : 800
Mean (usec)          : 981.227
Median (usec)        : 975.97
Min (usec)           : 813
Max (usec)           : 1994

Number of samples    : 10000
Expected wait (usec) : 500
Mean (usec)          : 975.899
Median (usec)        : 975.731
Min (usec)           : 745
Max (usec)           : 1488

Number of samples    : 10000
Expected wait (usec) : 100
Mean (usec)          : 975.812
Median (usec)        : 976.612
Min (usec)           : 421
Max (usec)           : 1230

Number of samples    : 10000
Expected wait (usec) : 50
Mean (usec)          : 975.373
Median (usec)        : 975.895
Min (usec)           : 179
Max (usec)           : 1233

Number of samples    : 10000
Expected wait (usec) : 10
Mean (usec)          : 972.895
Median (usec)        : 975.931
Min (usec)           : 59
Max (usec)           : 1270
```

#### With patch :
```
Number of samples    : 10000
Expected wait (usec) : 800
Mean (usec)          : 812.062
Median (usec)        : 808.066
Min (usec)           : 803
Max (usec)           : 1078

Number of samples    : 10000
Expected wait (usec) : 500
Mean (usec)          : 511.158
Median (usec)        : 507.992
Min (usec)           : 503
Max (usec)           : 831

Number of samples    : 10000
Expected wait (usec) : 100
Mean (usec)          : 106.495
Median (usec)        : 105
Min (usec)           : 103
Max (usec)           : 324

Number of samples    : 10000
Expected wait (usec) : 50
Mean (usec)          : 59.3095
Median (usec)        : 58.0607
Min (usec)           : 53
Max (usec)           : 304

Number of samples    : 10000
Expected wait (usec) : 10
Mean (usec)          : 18.5015
Median (usec)        : 18
Min (usec)           : 14
Max (usec)           : 140
```