### PR TITLE
Enables the timer scheduler's customization for both deadline and waitable timers

### DIFF
--- a/include/boost/asio/basic_deadline_timer.hpp
+++ b/include/boost/asio/basic_deadline_timer.hpp
@@ -122,7 +122,9 @@ namespace asio {
  */
 template <typename Time,
     typename TimeTraits = boost::asio::time_traits<Time>,
-    typename TimerService = deadline_timer_service<Time, TimeTraits> >
+    typename TimerSchedulerType = boost::asio::detail::timer_scheduler,
+    typename TimerService = deadline_timer_service<
+                              Time, TimeTraits, TimerSchedulerType> >
 class basic_deadline_timer
   : public basic_io_object<TimerService>
 {
@@ -132,6 +134,9 @@ public:
 
   /// The time type.
   typedef typename traits_type::time_type time_type;
+
+  /// The TimerSchedulerType.
+  typedef TimerSchedulerType timer_scheduler_type;
 
   /// The duration type.
   typedef typename traits_type::duration_type duration_type;

--- a/include/boost/asio/basic_waitable_timer.hpp
+++ b/include/boost/asio/basic_waitable_timer.hpp
@@ -123,7 +123,9 @@ namespace asio {
  */
 template <typename Clock,
     typename WaitTraits = boost::asio::wait_traits<Clock>,
-    typename WaitableTimerService = waitable_timer_service<Clock, WaitTraits> >
+    typename TimerSchedulerType = boost::asio::detail::timer_scheduler,
+    typename WaitableTimerService = waitable_timer_service<
+                                      Clock, WaitTraits, TimerSchedulerType> >
 class basic_waitable_timer
   : public basic_io_object<WaitableTimerService>
 {
@@ -139,6 +141,9 @@ public:
 
   /// The wait traits type.
   typedef WaitTraits traits_type;
+
+  /// The TimerSchedulerType.
+  typedef TimerSchedulerType timer_scheduler_type;
 
   /// Constructor.
   /**

--- a/include/boost/asio/deadline_timer_service.hpp
+++ b/include/boost/asio/deadline_timer_service.hpp
@@ -34,13 +34,14 @@ namespace asio {
 
 /// Default service implementation for a timer.
 template <typename TimeType,
-    typename TimeTraits = boost::asio::time_traits<TimeType> >
+    typename TimeTraits = boost::asio::time_traits<TimeType>,
+    typename TimerSchedulerType = boost::asio::detail::timer_scheduler>
 class deadline_timer_service
 #if defined(GENERATING_DOCUMENTATION)
   : public boost::asio::io_service::service
 #else
   : public boost::asio::detail::service_base<
-      deadline_timer_service<TimeType, TimeTraits> >
+      deadline_timer_service<TimeType, TimeTraits, TimerSchedulerType> >
 #endif
 {
 public:
@@ -48,6 +49,8 @@ public:
   /// The unique service identifier.
   static boost::asio::io_service::id id;
 #endif
+  /// The timer scheduler type
+  typedef TimerSchedulerType timer_scheduler_type;
 
   /// The time traits type.
   typedef TimeTraits traits_type;
@@ -60,7 +63,8 @@ public:
 
 private:
   // The type of the platform-specific implementation.
-  typedef detail::deadline_timer_service<traits_type> service_impl_type;
+  typedef detail::deadline_timer_service<
+    traits_type, timer_scheduler_type> service_impl_type;
 
 public:
   /// The implementation type of the deadline timer.
@@ -73,7 +77,8 @@ public:
   /// Construct a new timer service for the specified io_service.
   explicit deadline_timer_service(boost::asio::io_service& io_service)
     : boost::asio::detail::service_base<
-        deadline_timer_service<TimeType, TimeTraits> >(io_service),
+        deadline_timer_service<
+          TimeType, TimeTraits, TimerSchedulerType> >(io_service),
       service_impl_(io_service)
   {
   }

--- a/include/boost/asio/detail/deadline_timer_service.hpp
+++ b/include/boost/asio/detail/deadline_timer_service.hpp
@@ -41,7 +41,7 @@ namespace boost {
 namespace asio {
 namespace detail {
 
-template <typename Time_Traits>
+template <typename Time_Traits, typename TimerSchedulerType>
 class deadline_timer_service
 {
 public:
@@ -63,7 +63,7 @@ public:
 
   // Constructor.
   deadline_timer_service(boost::asio::io_service& io_service)
-    : scheduler_(boost::asio::use_service<timer_scheduler>(io_service))
+    : scheduler_(boost::asio::use_service<TimerSchedulerType>(io_service))
   {
     scheduler_.init_task();
     scheduler_.add_timer_queue(timer_queue_);

--- a/include/boost/asio/waitable_timer_service.hpp
+++ b/include/boost/asio/waitable_timer_service.hpp
@@ -30,13 +30,14 @@ namespace asio {
 
 /// Default service implementation for a timer.
 template <typename Clock,
-    typename WaitTraits = boost::asio::wait_traits<Clock> >
+    typename WaitTraits = boost::asio::wait_traits<Clock>,
+    typename TimerSchedulerType = boost::asio::detail::timer_scheduler>
 class waitable_timer_service
 #if defined(GENERATING_DOCUMENTATION)
   : public boost::asio::io_service::service
 #else
   : public boost::asio::detail::service_base<
-      waitable_timer_service<Clock, WaitTraits> >
+      waitable_timer_service<Clock, WaitTraits, TimerSchedulerType> >
 #endif
 {
 public:
@@ -57,10 +58,14 @@ public:
   /// The wait traits type.
   typedef WaitTraits traits_type;
 
+  /// The TimerSchedulerType.
+  typedef TimerSchedulerType timer_scheduler_type;
+
 private:
   // The type of the platform-specific implementation.
   typedef detail::deadline_timer_service<
-    detail::chrono_time_traits<Clock, WaitTraits> > service_impl_type;
+    detail::chrono_time_traits<Clock, WaitTraits>,
+    TimerSchedulerType> service_impl_type;
 
 public:
   /// The implementation type of the waitable timer.
@@ -73,7 +78,8 @@ public:
   /// Construct a new timer service for the specified io_service.
   explicit waitable_timer_service(boost::asio::io_service& io_service)
     : boost::asio::detail::service_base<
-        waitable_timer_service<Clock, WaitTraits> >(io_service),
+        waitable_timer_service<
+          Clock, WaitTraits, TimerSchedulerType> >(io_service),
       service_impl_(io_service)
   {
   }


### PR DESCRIPTION
This pull request is linked to pull request discussion #24

The discussion on timer precisions with @haegele-tv lead us to think that we have to design our own timer mechanism for the [boost asio udt](https://github.com/securesocketfunneling/udt) implementation requirements.

The perfect place to do so would be to design a specific timer scheduler (as it is done with WinRT, or Linux, Windows...) and benefit of the entire deadline/waitable timer io_objects and io_services architecture.

Yet, the timer scheduler is NOT customizable by the user. This patch allows third party developers to specify a custom timer scheduler for any specific requirements.

What do you think?
