### PR TITLE
Add additional checks to handle ERROR_MORE_DATA

### DIFF
--- a/include/boost/asio/detail/impl/socket_ops.ipp
+++ b/include/boost/asio/detail/impl/socket_ops.ipp
@@ -851,6 +851,10 @@ void complete_iocp_recv(state_type state,
   {
     ec = boost::asio::error::connection_refused;
   }
+  else if (ec.value() == ERROR_MORE_DATA)
+  {
+    ec = boost::asio::error::message_size;
+  }
 
   // Check for connection closed.
   else if (!ec && bytes_transferred == 0
@@ -989,6 +993,10 @@ void complete_iocp_recvfrom(
   else if (ec.value() == ERROR_PORT_UNREACHABLE)
   {
     ec = boost::asio::error::connection_refused;
+  }
+  else if (ec.value() == ERROR_MORE_DATA)
+  {
+    ec = boost::asio::error::message_size;
   }
 }
 


### PR DESCRIPTION
When receiving from a UDP socket, passing a buffer smaller than the received datagram should trigger a boost::asio::error::message_size error. However, when Windows' IOCP is being used, the system error 0xEA (ERROR_MORE_DATA) is returned instead. 

A quick repro is to use Daytime.6 example. When built with IOCP and a datagram larger than a single byte is sent, the process will terminate rather than sending a response. If IOCP is disabled with BOOST_ASIO_DISABLE_IOCP, the error code will be set to boost::asio::error::message_size and a response will be sent. The expected behaviour is mentioned in the example's documentation, "Since we only provide the 1-byte recv_buffer_ to contain the client's request, the io_service object would return an error if the client sent anything larger. We can ignore such an error if it comes up."

This patch maps ERROR_MORE_DATA to boost::asio::error::message_size when built with IOCP.

Daytime.6: http://www.boost.org/doc/libs/1_59_0/doc/html/boost_asio/tutorial/tutdaytime6/src.html
ERROR_MORE_DATA: https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382%28v=vs.85%29.aspx
