### PR TITLE
Fix data loss when async_read_some is pending

### DIFF
--- a/include/boost/asio/ssl/detail/io.hpp
+++ b/include/boost/asio/ssl/detail/io.hpp
@@ -225,8 +225,18 @@ public:
         }
 
         default:
-        if (bytes_transferred == ~std::size_t(0))
+        if (bytes_transferred == ~std::size_t(0)) {
+          if (want_ == engine::want_output) {
+            // Pass the result to the handler.
+            op_.call_handler(handler_,
+                core_.engine_.map_error_code(ec_),
+                ec_ ? 0 : bytes_transferred_);
+            return;
+          }
           bytes_transferred = 0; // Timer cancellation, no data transferred.
+          ec = boost::system::error_code();
+          continue;
+        }
         else if (!ec_)
           ec_ = ec;
 


### PR DESCRIPTION
When `ssl::stream::async_read_some` is pending, a cancel error, which is occured by `pending_read_`'s cancel,  is passed to a handler while some data is read from a SSL instance.
So, error code should be cleared.
In addition, `pending_read_` and `pending_write_` should be modified by an `io_op` instance which actually called IO operation, in order to be only one reading or writing operation is invoked.

There is another issue for the pending handling. Handlers for pending writing are called before the buffers corresponding to handlers are actually writen to underlying stream. But I have no idea for the issue.
