### PR TITLE
Remove deprecated SSL3 methods

### DIFF
--- a/include/boost/asio/ssl/impl/context.ipp
+++ b/include/boost/asio/ssl/impl/context.ipp
@@ -89,6 +89,14 @@ context::context(context::method m)
     handle_ = ::SSL_CTX_new(::SSLv2_server_method());
     break;
 #endif // defined(OPENSSL_NO_SSL2)
+#if defined(OPENSSL_NO_SSL3)
+  case context::sslv3:
+  case context::sslv3_client:
+  case context::sslv3_server:
+    boost::asio::detail::throw_error(
+        boost::asio::error::invalid_argument, "context");
+    break;
+#else // defined(OPENSSL_NO_SSL3)
   case context::sslv3:
     handle_ = ::SSL_CTX_new(::SSLv3_method());
     break;
@@ -98,6 +106,7 @@ context::context(context::method m)
   case context::sslv3_server:
     handle_ = ::SSL_CTX_new(::SSLv3_server_method());
     break;
+#endif // defined(OPENSSL_NO_SSL3)
   case context::tlsv1:
     handle_ = ::SSL_CTX_new(::TLSv1_method());
     break;


### PR DESCRIPTION
this patch removes the SSLv3 methods from ssl/impl/context.ipp when not available from libssl-dev.
