### PR TITLE
Fix duplicate definition of BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT

### DIFF
--- a/include/boost/asio/detail/config.hpp
+++ b/include/boost/asio/detail/config.hpp
@@ -222,11 +222,6 @@
 #   endif // defined(__GXX_EXPERIMENTAL_CXX0X__)
 #  endif // ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4)
 # endif // defined(__GNUC__)
-# if defined(BOOST_ASIO_MSVC)
-#  if (_MSC_VER >= 1900)
-#   define BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT noexcept(true)
-#  endif // (_MSC_VER >= 1900)
-# endif // defined(BOOST_ASIO_MSVC)
 # if !defined(BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT)
 #  define BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT
 # endif // !defined(BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT)


### PR DESCRIPTION
The BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT is already defined to BOOST_NOEXCEPT.
