### PR TITLE
Fix boringssl support.

### DIFF
--- a/include/boost/asio/ssl/detail/impl/engine.ipp
+++ b/include/boost/asio/ssl/detail/impl/engine.ipp
@@ -203,9 +203,15 @@ const boost::system::error_code& engine::map_error_code(
   // If there's data yet to be read, it's an error.
   if (BIO_wpending(ext_bio_))
   {
+#if defined(OPENSSL_IS_BORINGSSL)
+    ec = boost::system::error_code(
+        ERR_PACK(ERR_LIB_SSL, SSL_R_UNEXPECTED_RECORD),
+        boost::asio::error::get_ssl_category());
+#else
     ec = boost::system::error_code(
         ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ),
         boost::asio::error::get_ssl_category());
+#endif // defined(OPENSSL_IS_BORINGSSL)
     return ec;
   }
 
@@ -217,9 +223,15 @@ const boost::system::error_code& engine::map_error_code(
   // Otherwise, the peer should have negotiated a proper shutdown.
   if ((::SSL_get_shutdown(ssl_) & SSL_RECEIVED_SHUTDOWN) == 0)
   {
+#if defined(OPENSSL_IS_BORINGSSL)
+    ec = boost::system::error_code(
+        ERR_PACK(ERR_LIB_SSL, SSL_R_UNEXPECTED_RECORD),
+        boost::asio::error::get_ssl_category());
+#else
     ec = boost::system::error_code(
         ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ),
         boost::asio::error::get_ssl_category());
+#endif // defined(OPENSSL_IS_BORINGSSL)
   }
 
   return ec;


### PR DESCRIPTION
There are some incopatibilities between current version of asio in latest stable version of Boost (1.60.0) and the BoringSSL library, which prevents us from using them together:
- in boringssl, ERR_PACK macro takes only two arguments;
- there is no SSL_R_SHORT_READ value in boringssl.

This patch is inspired by 
https://gist.github.com/kzemek/37aa2a2138b2651f2c55 .
