### PR TITLE
Fix Helgrind warning on using pthread_cond_signal while unlocked

### DIFF
--- a/include/boost/asio/detail/posix_event.hpp
+++ b/include/boost/asio/detail/posix_event.hpp
@@ -66,9 +66,9 @@ public:
     BOOST_ASIO_ASSERT(lock.locked());
     state_ |= 1;
     bool have_waiters = (state_ > 1);
-    lock.unlock();
     if (have_waiters)
       ::pthread_cond_signal(&cond_); // Ignore EINVAL.
+    lock.unlock();
   }
 
   // If there's a waiter, unlock the mutex and signal it.
@@ -79,8 +79,8 @@ public:
     state_ |= 1;
     if (state_ > 1)
     {
-      lock.unlock();
       ::pthread_cond_signal(&cond_); // Ignore EINVAL.
+      lock.unlock();
       return true;
     }
     return false;


### PR DESCRIPTION
Helgrind would report a dubious use of pthread_cond_signal before this
patch. The original code was already correct, though, but this one seems
to be preferred.
