### PR TITLE
fully qualify handler_type<> template in BOOST_ASIO_HANDLER_TYPE macro

### DIFF
--- a/include/boost/asio/handler_type.hpp
+++ b/include/boost/asio/handler_type.hpp
@@ -109,6 +109,6 @@ struct handler_type<ReturnType(Arg1, Arg2, Arg3, Arg4, Arg5), Signature>
 #include <boost/asio/detail/pop_options.hpp>
 
 #define BOOST_ASIO_HANDLER_TYPE(h, sig) \
-  typename handler_type<h, sig>::type
+  typename ::boost::asio::handler_type<h, sig>::type
 
 #endif // BOOST_ASIO_HANDLER_TYPE_HPP


### PR DESCRIPTION
This allows developers to use the handler verification macros in custom services and streams, without this they will receive an error unless they define their code in the `::boost::asio` namespace or do a `using namespace boost::asio;` neither of which are ideal.