### PR TITLE
Fixed cross-compilation of tests

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,31 +5,15 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-import os ;
 import feature ;
 
-if [ os.name ] = SOLARIS
-{
-  lib socket ;
-  lib nsl ;
-}
-else if [ os.name ] = NT
-{
-  lib ws2_32 ;
-  lib mswsock ;
-}
-else if [ os.name ] = HPUX
-{
-  lib ipv6 ;
-}
-else if [ os.name ] = QNXNTO
-{
-  lib socket ;
-}
-else if [ os.name ] = HAIKU
-{
-  lib network ;
-}
+
+lib socket ; # SOLARIS, QNXNTO
+lib nsl ; # SOLARIS
+lib ws2_32 ; # NT
+lib mswsock ; # NT
+lib ipv6 ; # HPUX
+lib network ; # HAIKU
 
 local USE_SELECT =
   <define>BOOST_ASIO_DISABLE_DEV_POLL
@@ -45,22 +29,22 @@ project
     <library>/boost/regex//boost_regex
     <define>BOOST_ALL_NO_LIB=1
     <threading>multi
-    <os>LINUX:<define>_XOPEN_SOURCE=600
-    <os>LINUX:<define>_GNU_SOURCE=1
-    <os>SOLARIS:<define>_XOPEN_SOURCE=500
-    <os>SOLARIS:<define>__EXTENSIONS__
-    <os>SOLARIS:<library>socket
-    <os>SOLARIS:<library>nsl
-    <os>NT:<define>_WIN32_WINNT=0x0501
-    <os>NT,<toolset>cw:<library>ws2_32
-    <os>NT,<toolset>cw:<library>mswsock
-    <os>NT,<toolset>gcc:<library>ws2_32
-    <os>NT,<toolset>gcc:<library>mswsock
-    <os>NT,<toolset>gcc-cygwin:<define>__USE_W32_SOCKETS
-    <os>HPUX,<toolset>gcc:<define>_XOPEN_SOURCE_EXTENDED
-    <os>HPUX:<library>ipv6
-    <os>QNXNTO:<library>socket
-    <os>HAIKU:<library>network
+    <target-os>linux:<define>_XOPEN_SOURCE=600
+    <target-os>linux:<define>_GNU_SOURCE=1
+    <target-os>solaris:<define>_XOPEN_SOURCE=500
+    <target-os>solaris:<define>__EXTENSIONS__
+    <target-os>solaris:<library>socket
+    <target-os>solaris:<library>nsl
+    <target-os>windows:<define>_WIN32_WINNT=0x0501
+    <target-os>windows,<toolset>cw:<library>ws2_32
+    <target-os>windows,<toolset>cw:<library>mswsock
+    <target-os>windows,<toolset>gcc:<library>ws2_32
+    <target-os>windows,<toolset>gcc:<library>mswsock
+    <target-os>windows,<toolset>gcc-cygwin:<define>__USE_W32_SOCKETS
+    <target-os>hpux,<toolset>gcc:<define>_XOPEN_SOURCE_EXTENDED
+    <target-os>hpux:<library>ipv6
+    <target-os>qnxnto:<library>socket
+    <target-os>haiku:<library>network
   ;
 
 test-suite "asio" :


### PR DESCRIPTION
Removed the use of the "os" feature as it reflects the host and not the target when cross-compiling.

All platform libs are declared unconditionally since I don't believe it's possible to use target-os in module scope. Declaring unused and unavailable libs does no harm.

Replaced \<os\> with \<target-os\> so that the correct options for the target are selected when cross-compiling. It works when not cross-compiling as well.

This is needed and is working for my regression test runner for QNX 6.6.0 which is cross-compiling from Linux to QNX.

I have checked the validity of the values provided for target-os against the feature definition in  build/src/tools/builtin.jam.