### PR TITLE
Fix ticket #12710: https://svn.boost.org/trac10/ticket/12710

### DIFF
--- a/include/boost/asio/ssl/detail/impl/engine.ipp
+++ b/include/boost/asio/ssl/detail/impl/engine.ipp
@@ -212,13 +212,13 @@ const boost::system::error_code& engine::map_error_code(
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
   if (ssl_->version == SSL2_VERSION)
     return ec;
-#endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
 
   // Otherwise, the peer should have negotiated a proper shutdown.
   if ((::SSL_get_shutdown(ssl_) & SSL_RECEIVED_SHUTDOWN) == 0)
   {
     ec = boost::asio::ssl::error::stream_truncated;
   }
+#endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
 
   return ec;
 }


### PR DESCRIPTION
As it is, OpenSSL 1.1.0 SSL together with current Boost.Asio is simply unusable.

This patch fixes a persistent stream_truncated error that prevents any reads.

Note that OpenSSL team explains that one of the major changes between OpenSSL 1.0.2h and OpenSSL 1.1.0 was the rewritten SSL/TLS state machine, version negotiation, and record layer.

See ​https://www.openssl.org/news/openssl-1.1.0-notes.html for reference. 