### PR TITLE
Add the coroutine::is_suspended() member function

### DIFF
--- a/include/boost/asio/coroutine.hpp
+++ b/include/boost/asio/coroutine.hpp
@@ -254,6 +254,11 @@ public:
   /// Returns true if the coroutine has reached its terminal state.
   bool is_complete() const { return value_ == -1; }
 
+  /**
+   * Returns true if the coroutine has yielded at least once and has not
+   * reached its terminal state.
+   */
+  bool is_suspended() const { return value_ > 0; }
 private:
   friend class detail::coroutine_ref;
   int value_;


### PR DESCRIPTION
```is_suspended()``` allows checking if the coroutine is in a suspended state. This is especially useful when implementing the ```asio_is_continuation()``` customization hook of composed operations
based on stackless coroutines.
@vinniefalco