### PR TITLE
Make buffer_copy safe to call on default constructed buffers

### DIFF
--- a/include/boost/asio/buffer.hpp
+++ b/include/boost/asio/buffer.hpp
@@ -1921,7 +1921,8 @@ inline std::size_t buffer_copy_1(const mutable_buffer& target,
   std::size_t target_size = target.size();
   std::size_t source_size = source.size();
   std::size_t n = target_size < source_size ? target_size : source_size;
-  memcpy(target.data(), source.data(), n);
+  if (n > 0)
+    memcpy(target.data(), source.data(), n);
   return n;
 }
 


### PR DESCRIPTION
Previously a call to memcpy() with a null pointer could occur, which resulted in UB.
This is an alternative to #67.