### PR TITLE
SSL input buffer

### DIFF
--- a/include/boost/asio/ssl/detail/stream_core.hpp
+++ b/include/boost/asio/ssl/detail/stream_core.hpp
@@ -120,7 +120,7 @@ struct stream_core
   std::vector<unsigned char> input_buffer_space_;
 
   // A buffer that may be used to read input intended for the engine.
-  const boost::asio::mutable_buffer input_buffer_;
+  const boost::asio::mutable_buffers_1 input_buffer_;
 
   // The buffer pointing to the engine's unconsumed input.
   boost::asio::const_buffer input_;


### PR DESCRIPTION
Fix for https://github.com/boostorg/asio/issues/74

This makes the ``ssl::stream`` call ``read_some()`` on its underlying socket type with a *MutableBufferSequence* rather than just a ``mutable_buffer``.