### PR TITLE
Fix consuming_buffers's specialization for null_buffers

### DIFF
--- a/include/boost/asio/detail/consuming_buffers.hpp
+++ b/include/boost/asio/detail/consuming_buffers.hpp
@@ -401,7 +401,7 @@ public:
     // No-op.
   }
 
-  std::size_t total_consume() const
+  std::size_t total_consumed() const
   {
     return 0;
   }


### PR DESCRIPTION
The specialization for null_buffers has a typo on the name of the method `total_consumed`, it misses the final "d".