### PR TITLE
Suppress [[nodiscard]] iterator dereference warning

### DIFF
--- a/include/boost/asio/buffer.hpp
+++ b/include/boost/asio/buffer.hpp
@@ -27,6 +27,7 @@
 #include <boost/asio/detail/string_view.hpp>
 #include <boost/asio/detail/throw_exception.hpp>
 #include <boost/asio/detail/type_traits.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #if defined(BOOST_ASIO_MSVC) && (BOOST_ASIO_MSVC >= 1700)
 # if defined(_HAS_ITERATOR_DEBUGGING) && (_HAS_ITERATOR_DEBUGGING != 0)
@@ -707,7 +708,7 @@ public:
 
   void operator()()
   {
-    *iter_;
+    boost::ignore_unused(*iter_);
   }
 
 private:


### PR DESCRIPTION
The call operator in `buffer_debug_check` dereferences its member `Iterator` object, which can raise a warning when `Iterator` is, e.g., a `std::vector` iterator whose dereference operator is marked `[[nodiscard]]`. In MSVC using `/std:c++17` this raises warning C4834. This PR silences the warning by using `boost::ignore_unused`. 
