### PR TITLE
spawn: decay argument types for coro_async_result

### DIFF
--- a/include/boost/asio/impl/spawn.hpp
+++ b/include/boost/asio/impl/spawn.hpp
@@ -245,7 +245,7 @@ public:
   explicit async_result(
     typename detail::coro_async_result<Handler,
       typename decay<Arg1>::type>::completion_handler_type& h)
-    : detail::coro_async_result<Handler, Arg1>(h)
+    : detail::coro_async_result<Handler, typename decay<Arg1>::type>(h)
   {
   }
 };
@@ -273,7 +273,7 @@ public:
   explicit async_result(
     typename detail::coro_async_result<Handler,
       typename decay<Arg2>::type>::completion_handler_type& h)
-    : detail::coro_async_result<Handler, Arg2>(h)
+    : detail::coro_async_result<Handler, typename decay<Arg2>::type>(h)
   {
   }
 };


### PR DESCRIPTION
if the coroutine result type is a reference or has a cv-qualifier (i.e.
when Arg != decay\<Arg>::type), the async_result<> specialization for
yield_context fails to compile because the template parameters don't
match between the base class and its constructor call

this means that initiating functions with signatures like void(T&&)
and void(error_code, T&&) can't be used with yield_context