### PR TITLE
Asio bad_address_cast fix under no exceptions

### DIFF
--- a/include/boost/asio/ip/bad_address_cast.hpp
+++ b/include/boost/asio/ip/bad_address_cast.hpp
@@ -25,7 +25,12 @@ namespace asio {
 namespace ip {
 
 /// Thrown to indicate a failed address conversion.
-class bad_address_cast : public std::bad_cast
+class bad_address_cast : 
+#if defined(BOOST_MSVC) && defined(_HAS_EXCEPTIONS) && !_HAS_EXCEPTIONS 
+        public std::exception 
+#else 
+        public std::bad_cast 
+#endif
 {
 public:
   /// Default constructor.


### PR DESCRIPTION
When using the Asio module in MSVC when exceptions are disabled, deriving an exception from bad_cast throws a linker error. A simple fix would look similar to the lexical_cast, bad_any_cast, etc.

Linked to bug #13607