### PR TITLE
Unbreak build against libc++ 7

### DIFF
--- a/include/boost/asio/detail/config.hpp
+++ b/include/boost/asio/detail/config.hpp
@@ -777,7 +777,7 @@
 #if !defined(BOOST_ASIO_HAS_STD_STRING_VIEW)
 # if !defined(BOOST_ASIO_DISABLE_STD_STRING_VIEW)
 #  if defined(__clang__)
-#   if (__cplusplus >= 201703)
+#   if defined(BOOST_ASIO_HAS_CLANG_LIBCXX) || (__cplusplus >= 201703)
 #    if __has_include(<string_view>)
 #     define BOOST_ASIO_HAS_STD_STRING_VIEW 1
 #    endif // __has_include(<string_view>)


### PR DESCRIPTION
libc++ >= 7 [lacks](https://reviews.llvm.org/rL324290) `<experimental/string_view>` while libc++ < 4 [may not](https://reviews.llvm.org/rL276238) have `<string_view>`. Found [downstream](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=230401).
