### PR TITLE
fix singleton not work correctly (windows implementation)

### DIFF
--- a/include/boost/asio/detail/win_global.hpp
+++ b/include/boost/asio/detail/win_global.hpp
@@ -59,7 +59,7 @@ T& win_global()
   {
     win_global_impl<T>::mutex_.init();
     static_mutex::scoped_lock lock(win_global_impl<T>::mutex_);
-    win_global_impl<T>::ptr_ = new T;
+    if (win_global_impl<T>::ptr_ == 0) win_global_impl<T>::ptr_ = new T;
     win_global_impl<T>::tss_ptr_ = win_global_impl<T>::ptr_;
   }
 

--- a/include/boost/asio/impl/thread_pool.ipp
+++ b/include/boost/asio/impl/thread_pool.ipp
@@ -45,7 +45,7 @@ thread_pool::thread_pool()
 }
 
 thread_pool::thread_pool(std::size_t num_threads)
-  : scheduler_(use_service<detail::scheduler>(*this))
+  : scheduler_(make_service<detail::scheduler>(*this, (num_threads == 1) ? ASIO_CONCURRENCY_HINT_1 : 0))
 {
   scheduler_.work_started();
 


### PR DESCRIPTION
The original code create new instance for each different calling
threads, instead of just one.

This singleton used by system_executor, thus everytime calling
 post(system_executor(), [] () { /* worker function /* });
from new thread create additional cpu_corex2 threads, then eating
up resources quickly.