### PR TITLE
Fix infinite loop in timer_queue::get_ready_timers

### DIFF
--- a/include/boost/asio/detail/timer_queue.hpp
+++ b/include/boost/asio/detail/timer_queue.hpp
@@ -267,11 +267,13 @@ private:
     {
       if (index == heap_.size() - 1)
       {
+        heap_.back().timer_->heap_index_ = (std::numeric_limits<std::size_t>::max)();
         heap_.pop_back();
       }
       else
       {
         swap_heap(index, heap_.size() - 1);
+        heap_.back().timer_->heap_index_ = (std::numeric_limits<std::size_t>::max)();
         heap_.pop_back();
         if (index > 0 && Time_Traits::less_than(
               heap_[index].time_, heap_[(index - 1) / 2].time_))


### PR DESCRIPTION
If cancelled timer has been moved then timer_queue::move_timer can
rewrite other timer in the timer_queue::heap_. It leads to an
infinite loop in `timer_queue::get_ready_timers`.

This happens by following scenario:
1. [timer_queue::cancel_timer](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L176) calls [timer_queue::remove_timer](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L191);

Assume `canceled_timer_index` = `timer_queue::heap_.size() - 1`;

2. [timer_queue::remove_timer](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L262) calls [timer_queue::heap_.pop_back()](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L275) (timer
still `has heap_index_` = `canceled_timer_index`);
3. [timer_queue::enqueue_timer](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L80) calls [timer_queue::heap_.push_back()](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L96) (new
timer object is assigned to `canceled_timer_index` position);
4. [timer_queue::move_timer](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L197) [assing](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L205) to `canceled_timer_index` position cancelled timer;

After this heap is broken. Then following could happen;

* `timer_queue::remove_timer` call for rewrited timer;
* `timer_queue::enqueue_timer` call for timer already in the heap;
* `timer_queue::get_ready_timers` gets into an infinite loop;

For a cancelled timer with `heap_index_` = `std::numeric_limits<std::size_t>::max()` the [condition](https://github.com/boostorg/asio/blob/fbe86d86b1ac53e40444e5af03ca4a6c74c33bda/include/boost/asio/detail/timer_queue.hpp#L204) will never be passed.