### PR TITLE
fixed return value construction

### DIFF
--- a/include/boost/asio/ip/basic_resolver_results.hpp
+++ b/include/boost/asio/ip/basic_resolver_results.hpp
@@ -253,7 +253,7 @@ public:
   {
     basic_resolver_results tmp(*this);
     tmp.index_ = 0;
-    return tmp;
+    return std::move(tmp);
   }
 
   /// Obtain an end iterator for the results range.


### PR DESCRIPTION
Warning from clang 7:

```
$(BOOST_ROOT)/boost/asio/ip/basic_resolver_results.hpp:256:12: warning: local variable 'tmp' will be copied despite being returned by name [-Wreturn-std-move]
    return tmp;
           ^~~
[...]
$(BOOST_ROOT)/boost/asio/ip/basic_resolver_results.hpp:256:12: note: call 'std::move' explicitly to avoid copying
    return tmp;
           ^~~
           std::move(tmp)
```