### PR TITLE
Remove all NUL-terminated characters from sun_path on OpenBSD

### DIFF
--- a/include/boost/asio/local/detail/impl/endpoint.ipp
+++ b/include/boost/asio/local/detail/impl/endpoint.ipp
@@ -66,8 +66,13 @@ void endpoint::resize(std::size_t new_size)
       - offsetof(boost::asio::detail::sockaddr_un_type, sun_path);
 
     // The path returned by the operating system may be NUL-terminated.
-    if (path_length_ > 0 && data_.local.sun_path[path_length_ - 1] == 0)
-      --path_length_;
+    // Names that start with a NUL are in the UNIX domain protocol's
+    // "abstract namespace" and are not NUL-terminated.
+    if (path_length_ > 0 && data_.local.sun_path[0] != 0
+        && data_.local.sun_path[path_length_ - 1] == 0) {
+      const char *end = strrchr(data_.local.sun_path, 0);
+      path_length_ = end - &data_.local.sun_path[0];
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #161.