### PR TITLE
Fix spurious "success" on SSL system errors:

### DIFF
--- a/include/boost/asio/ssl/error.hpp
+++ b/include/boost/asio/ssl/error.hpp
@@ -46,11 +46,15 @@ enum stream_errors
 #if defined(GENERATING_DOCUMENTATION)
   /// The underlying stream closed before the ssl stream gracefully shut down.
   stream_truncated
+
 #elif (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_IS_BORINGSSL)
   stream_truncated = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)
 #else
   stream_truncated = 1
 #endif
+
+  /// An unspecified system error occurred during an ssl read operation.
+  ,read_sys_error = stream_truncated + 1
 };
 
 extern BOOST_ASIO_DECL

--- a/include/boost/asio/ssl/impl/error.ipp
+++ b/include/boost/asio/ssl/impl/error.ipp
@@ -77,6 +77,7 @@ public:
     switch (value)
     {
     case stream_truncated: return "stream truncated";
+    case read_sys_error: return "sys_error=0 on read";
     default: return "asio.ssl.stream error";
     }
   }


### PR DESCRIPTION
Fix boostorg/beast#807
Fix boostorg/beast#1373

This resolves an issue where an ssl::stream read operation
returns a successful error code but zero bytes transferred,
violating its contract.

* Treat SSL_ERROR_ZERO_RETURN as EOF

* Use the ssl category for sys_error

* On error, if sys_error is 0 (success),
  return ssl::errors::read_sys_error instead.