### PR TITLE
Fix missing Error Alert after "handshake failure"

### DIFF
--- a/include/boost/asio/ssl/detail/impl/engine.ipp
+++ b/include/boost/asio/ssl/detail/impl/engine.ipp
@@ -241,6 +241,10 @@ engine::want engine::perform(int (engine::* op)(void*, std::size_t),
   {
     ec = boost::system::error_code(sys_error,
         boost::asio::error::get_ssl_category());
+    if (pending_output_after > pending_output_before)
+    {
+      return want_output;
+    }
     return want_nothing;
   }
 


### PR DESCRIPTION
The Error Alerts were correctly generated by OpenSSL
and put into the BIO, but the BIO was not processed by ASIO and
the socket closed despite unprocessed packets in the BIO.

fixes boostorg/asio#189