### PR TITLE
refactor: remove unused endpoint variables in tests

### DIFF
--- a/test/generic/raw_protocol.cpp
+++ b/test/generic/raw_protocol.cpp
@@ -161,12 +161,6 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    rp::endpoint endpoint1 = socket1.local_endpoint();
-    rp::endpoint endpoint2 = socket1.local_endpoint(ec);
-
-    rp::endpoint endpoint3 = socket1.remote_endpoint();
-    rp::endpoint endpoint4 = socket1.remote_endpoint(ec);
-
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);
 

--- a/test/generic/seq_packet_protocol.cpp
+++ b/test/generic/seq_packet_protocol.cpp
@@ -157,12 +157,6 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    spp::endpoint endpoint1 = socket1.local_endpoint();
-    spp::endpoint endpoint2 = socket1.local_endpoint(ec);
-
-    spp::endpoint endpoint3 = socket1.remote_endpoint();
-    spp::endpoint endpoint4 = socket1.remote_endpoint(ec);
-
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);
 

--- a/test/generic/stream_protocol.cpp
+++ b/test/generic/stream_protocol.cpp
@@ -177,12 +177,6 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    sp::endpoint endpoint1 = socket1.local_endpoint();
-    sp::endpoint endpoint2 = socket1.local_endpoint(ec);
-
-    sp::endpoint endpoint3 = socket1.remote_endpoint();
-    sp::endpoint endpoint4 = socket1.remote_endpoint(ec);
-
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);
 


### PR DESCRIPTION
There are several unused `endpoint` variables in tests, look like copy/paste across files.