### PR TITLE
(In progress) Define port_t type for endpoint's port number

### DIFF
--- a/include/boost/asio/ip/detail/endpoint.hpp
+++ b/include/boost/asio/ip/detail/endpoint.hpp
@@ -33,15 +33,17 @@ namespace detail {
 class endpoint
 {
 public:
+  // The type of an endpoint's port.
+  typedef unsigned short port_t;
+
   // Default constructor.
   BOOST_ASIO_DECL endpoint();
 
   // Construct an endpoint using a family and port number.
-  BOOST_ASIO_DECL endpoint(int family, unsigned short port_num);
+  BOOST_ASIO_DECL endpoint(int family, port_t port_num);
 
   // Construct an endpoint using an address and port number.
-  BOOST_ASIO_DECL endpoint(const boost::asio::ip::address& addr,
-      unsigned short port_num);
+  BOOST_ASIO_DECL endpoint(const boost::asio::ip::address& addr, port_t port_num);
 
   // Copy constructor.
   endpoint(const endpoint& other)
@@ -87,10 +89,10 @@ public:
   }
 
   // Get the port associated with the endpoint.
-  BOOST_ASIO_DECL unsigned short port() const;
+  BOOST_ASIO_DECL port_t port() const;
 
   // Set the port associated with the endpoint.
-  BOOST_ASIO_DECL void port(unsigned short port_num);
+  BOOST_ASIO_DECL void port(port_t port_num);
 
   // Get the IP address associated with the endpoint.
   BOOST_ASIO_DECL boost::asio::ip::address address() const;

--- a/test/generic/raw_protocol.cpp
+++ b/test/generic/raw_protocol.cpp
@@ -161,12 +161,6 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    rp::endpoint endpoint1 = socket1.local_endpoint();
-    rp::endpoint endpoint2 = socket1.local_endpoint(ec);
-
-    rp::endpoint endpoint3 = socket1.remote_endpoint();
-    rp::endpoint endpoint4 = socket1.remote_endpoint(ec);
-
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);
 

--- a/test/generic/seq_packet_protocol.cpp
+++ b/test/generic/seq_packet_protocol.cpp
@@ -157,12 +157,6 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    spp::endpoint endpoint1 = socket1.local_endpoint();
-    spp::endpoint endpoint2 = socket1.local_endpoint(ec);
-
-    spp::endpoint endpoint3 = socket1.remote_endpoint();
-    spp::endpoint endpoint4 = socket1.remote_endpoint(ec);
-
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);
 

--- a/test/generic/stream_protocol.cpp
+++ b/test/generic/stream_protocol.cpp
@@ -177,12 +177,6 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    sp::endpoint endpoint1 = socket1.local_endpoint();
-    sp::endpoint endpoint2 = socket1.local_endpoint(ec);
-
-    sp::endpoint endpoint3 = socket1.remote_endpoint();
-    sp::endpoint endpoint4 = socket1.remote_endpoint(ec);
-
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);
 


### PR DESCRIPTION
Just inspired by `size_t`, would it be a little more readable to use `port_t` instead of `unsigned short`? If yes I'll check and update everywhere.

And it can be used in consumer code too, for example:

```
class ServerBase {
public:
  ServerBase(boost::asio::port_t port = 8000) {}
};
```