### PR TITLE
windows overlapped_ptr constructs with an execution_context

### DIFF
--- a/include/boost/asio/detail/win_iocp_overlapped_op.hpp
+++ b/include/boost/asio/detail/win_iocp_overlapped_op.hpp
@@ -20,6 +20,7 @@
 #if defined(BOOST_ASIO_HAS_IOCP)
 
 #include <boost/asio/error.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/detail/bind_handler.hpp>
 #include <boost/asio/detail/fenced_block.hpp>
 #include <boost/asio/detail/handler_alloc_helpers.hpp>
@@ -33,15 +34,16 @@ namespace boost {
 namespace asio {
 namespace detail {
 
-template <typename Handler>
+template <typename Executor, typename Handler>
 class win_iocp_overlapped_op : public operation
 {
 public:
   BOOST_ASIO_DEFINE_HANDLER_PTR(win_iocp_overlapped_op);
 
-  win_iocp_overlapped_op(Handler& handler)
+  win_iocp_overlapped_op(const Executor& ex, Handler& handler)
     : operation(&win_iocp_overlapped_op::do_complete),
-      handler_(BOOST_ASIO_MOVE_CAST(Handler)(handler))
+      handler_(BOOST_ASIO_MOVE_CAST(Handler)(handler)),
+      work_(ex)
   {
     handler_work<Handler>::start(handler_);
   }
@@ -79,6 +81,7 @@ public:
 
 private:
   Handler handler_;
+  executor_work_guard<Executor> work_;
 };
 
 } // namespace detail

--- a/include/boost/asio/windows/overlapped_ptr.hpp
+++ b/include/boost/asio/windows/overlapped_ptr.hpp
@@ -50,10 +50,20 @@ public:
   }
 
   /// Construct an overlapped_ptr to contain the specified handler.
-  template <typename Handler>
-  explicit overlapped_ptr(boost::asio::io_context& io_context,
-      BOOST_ASIO_MOVE_ARG(Handler) handler)
-    : impl_(io_context, BOOST_ASIO_MOVE_CAST(Handler)(handler))
+  template <typename Executor, typename Handler>
+  overlapped_ptr(
+      const Executor& ex, BOOST_ASIO_MOVE_ARG(Handler) handler)
+    : impl_(ex, BOOST_ASIO_MOVE_CAST(Handler)(handler))
+  {
+  }
+
+  /// Construct an overlapped_ptr to contain the specified handler.
+  template <typename ExecutionContext, typename Handler>
+  overlapped_ptr(ExecutionContext& context,
+      BOOST_ASIO_MOVE_ARG(Handler) handler, typename enable_if<
+        is_convertible<ExecutionContext&, execution_context&>::value
+      >::type* = 0)
+      : impl_(context, BOOST_ASIO_MOVE_CAST(Handler)(handler))
   {
   }
 


### PR DESCRIPTION
This needs to be audited to make sure that none of the associated executors run out of work.

fix chriskohlhoff/asio#369