### PR TITLE
In buffers_iterator::decrement, remove unnecessary bounds check.

### DIFF
--- a/include/boost/asio/buffers_iterator.hpp
+++ b/include/boost/asio/buffers_iterator.hpp
@@ -387,10 +387,12 @@ private:
       return;
     }
 
-    // Find the previous non-empty buffer.
+    // Find the previous non-empty buffer, which must exist,
+    // otherwise position_ could not have been > 0.
     buffer_sequence_iterator_type iter = current_;
-    while (iter != begin_)
+    for (;;)
     {
+      BOOST_ASIO_ASSERT(iter != begin_);
       --iter;
       buffer_type buffer = *iter;
       std::size_t buffer_size = buffer.size();


### PR DESCRIPTION
I checked with gcc, and removing the check does actually produce more efficient machine code.