### PR TITLE
Update VxWorks Support, add serial support for VxWorks

### DIFF
--- a/include/boost/asio/detail/config.hpp
+++ b/include/boost/asio/detail/config.hpp
@@ -847,6 +847,13 @@
 # endif // !defined(BOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW)
 #endif // !defined(BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW)
 
+#if defined(__VXWORKS__)
+// gcc 8 provides the headers but they are not used in VxWorks
+// clang does not provide them.
+#undef BOOST_ASIO_HAS_STD_STRING_VIEW
+#undef BOOST_ASIO_HAS_STD_EXPERIMENTAL_STRING_VIEW
+#endif
+
 // Standard library has a string_view that we can use.
 #if !defined(BOOST_ASIO_HAS_STRING_VIEW)
 # if !defined(BOOST_ASIO_DISABLE_STRING_VIEW)
@@ -1131,7 +1138,8 @@
 # if !defined(BOOST_ASIO_DISABLE_POSIX_STREAM_DESCRIPTOR)
 #  if !defined(BOOST_ASIO_WINDOWS) \
   && !defined(BOOST_ASIO_WINDOWS_RUNTIME) \
-  && !defined(__CYGWIN__)
+  && !defined(__CYGWIN__) \
+  && (defined(BOOST_ASIO_HAS_DEV_POLL) || defined(BOOST_ASIO_HAS_DEV_EPOLL))
 #   define BOOST_ASIO_HAS_POSIX_STREAM_DESCRIPTOR 1
 #  endif // !defined(BOOST_ASIO_WINDOWS)
          //   && !defined(BOOST_ASIO_WINDOWS_RUNTIME)

--- a/include/boost/asio/detail/impl/reactive_serial_port_service.ipp
+++ b/include/boost/asio/detail/impl/reactive_serial_port_service.ipp
@@ -21,6 +21,10 @@
 #if defined(BOOST_ASIO_HAS_SERIAL_PORT)
 #if !defined(BOOST_ASIO_WINDOWS) && !defined(__CYGWIN__)
 
+#ifdef __VXWORKS__
+#include <ioLib.h>
+#endif
+
 #include <cstring>
 #include <boost/asio/detail/reactive_serial_port_service.hpp>
 
@@ -67,7 +71,10 @@ boost::system::error_code reactive_serial_port_service::open(
     descriptor_ops::close(fd, state, ignored_ec);
     return ec;
   }
-
+#ifdef __VXWORKS__
+  s = descriptor_ops::error_wrapper(::ioctl(
+         fd, FIOSETOPTIONS, OPT_RAW), ec);
+#else  
   // Set up default serial port options.
   termios ios;
   errno = 0;
@@ -89,6 +96,7 @@ boost::system::error_code reactive_serial_port_service::open(
     errno = 0;
     s = descriptor_ops::error_wrapper(::tcsetattr(fd, TCSANOW, &ios), ec);
   }
+#endif
   if (s < 0)
   {
     boost::system::error_code ignored_ec;
@@ -113,8 +121,18 @@ boost::system::error_code reactive_serial_port_service::do_set_option(
 {
   termios ios;
   errno = 0;
+#if  defined (__VXWORKS__)
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl), 
+					FIOGETOPTIONS, &ios.tty_iflag),ec);
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl), 
+					SIO_HW_OPTS_GET, &ios.c_cflag), ec);
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl), 
+					SIO_BAUD_GET, &ios.BaudRate), ec);
+#else
+
   descriptor_ops::error_wrapper(::tcgetattr(
         descriptor_service_.native_handle(impl), &ios), ec);
+#endif
   if (ec)
     return ec;
 
@@ -122,8 +140,17 @@ boost::system::error_code reactive_serial_port_service::do_set_option(
     return ec;
 
   errno = 0;
+#if  defined (__VXWORKS__)
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl),
+					FIOSETOPTIONS, &ios.tty_iflag), ec);
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl),
+					SIO_HW_OPTS_SET, &ios.c_cflag), ec);
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl),
+					SIO_BAUD_SET, &ios.BaudRate), ec);
+#else
   descriptor_ops::error_wrapper(::tcsetattr(
         descriptor_service_.native_handle(impl), TCSANOW, &ios), ec);
+#endif
   return ec;
 }
 
@@ -134,8 +161,17 @@ boost::system::error_code reactive_serial_port_service::do_get_option(
 {
   termios ios;
   errno = 0;
+#if  defined (__VXWORKS__)
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl),
+					FIOGETOPTIONS, &ios.tty_iflag),ec);
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl),
+					SIO_HW_OPTS_GET, &ios.c_cflag), ec);
+  descriptor_ops::error_wrapper(::ioctl(descriptor_service_.native_handle(impl),
+					SIO_BAUD_GET, &ios.BaudRate), ec);
+#else
   descriptor_ops::error_wrapper(::tcgetattr(
         descriptor_service_.native_handle(impl), &ios), ec);
+#endif
   if (ec)
     return ec;
 

--- a/include/boost/asio/detail/reactive_serial_port_service.hpp
+++ b/include/boost/asio/detail/reactive_serial_port_service.hpp
@@ -141,8 +141,10 @@ public:
       boost::system::error_code& ec)
   {
     errno = 0;
+#ifndef __VXWORKS__
     descriptor_ops::error_wrapper(::tcsendbreak(
           descriptor_service_.native_handle(impl), 0), ec);
+#endif
     return ec;
   }
 

--- a/include/boost/asio/detail/socket_types.hpp
+++ b/include/boost/asio/detail/socket_types.hpp
@@ -62,7 +62,9 @@
    || defined(__OpenBSD__) || defined(__linux__) \
    || defined(__EMSCRIPTEN__)
 #  include <poll.h>
-# elif !defined(__SYMBIAN32__)
+# elif !defined(__SYMBIAN32__) && !defined(__VXWORKS__ )
+#  include <sys/poll.h>
+# elif defined(__VXWORKS__ ) && (_WRS_VXWORKS_MAJOR > 6 )
 #  include <sys/poll.h>
 # endif
 # include <sys/types.h>

--- a/include/boost/asio/ip/detail/socket_option.hpp
+++ b/include/boost/asio/ip/detail/socket_option.hpp
@@ -148,6 +148,17 @@ public:
     }
     else
     {
+#ifdef __VXWORKS__
+      /*
+       * In VxWorks, the stack sets the *optlen value to 1 byte
+       * for IP_MULTICAST_LOOP.
+       */
+      if (s == 1)
+      {
+          ipv4_value_ = *reinterpret_cast<char*>(&ipv4_value_) ? 1 : 0;
+      }
+      else
+#endif
       if (s != sizeof(ipv4_value_))
       {
         std::length_error ex("multicast_enable_loopback socket option resize");

--- a/include/boost/asio/ip/impl/network_v4.ipp
+++ b/include/boost/asio/ip/impl/network_v4.ipp
@@ -133,7 +133,7 @@ std::string network_v4::to_string(boost::system::error_code& ec) const
 #if defined(BOOST_ASIO_HAS_SECURE_RTL)
   sprintf_s(prefix_len, sizeof(prefix_len), "/%u", prefix_length_);
 #else // defined(BOOST_ASIO_HAS_SECURE_RTL)
-  sprintf(prefix_len, "/%u", prefix_length_);
+  std::sprintf(prefix_len, "/%u", prefix_length_);
 #endif // defined(BOOST_ASIO_HAS_SECURE_RTL)
   return address_.to_string() + prefix_len;
 }

--- a/include/boost/asio/ip/impl/network_v6.ipp
+++ b/include/boost/asio/ip/impl/network_v6.ipp
@@ -102,7 +102,7 @@ std::string network_v6::to_string(boost::system::error_code& ec) const
 #if defined(BOOST_ASIO_HAS_SECURE_RTL)
   sprintf_s(prefix_len, sizeof(prefix_len), "/%u", prefix_length_);
 #else // defined(BOOST_ASIO_HAS_SECURE_RTL)
-  sprintf(prefix_len, "/%u", prefix_length_);
+  std::sprintf(prefix_len, "/%u", prefix_length_);
 #endif // defined(BOOST_ASIO_HAS_SECURE_RTL)
   return address_.to_string() + prefix_len;
 }

--- a/include/boost/asio/serial_port_base.hpp
+++ b/include/boost/asio/serial_port_base.hpp
@@ -21,7 +21,7 @@
 #if defined(BOOST_ASIO_HAS_SERIAL_PORT) \
   || defined(GENERATING_DOCUMENTATION)
 
-#if !defined(BOOST_ASIO_WINDOWS) && !defined(__CYGWIN__)
+#if !defined(BOOST_ASIO_WINDOWS) && !defined(__CYGWIN__) && !defined(__VXWORKS__)
 # include <termios.h>
 #endif // !defined(BOOST_ASIO_WINDOWS) && !defined(__CYGWIN__)
 
@@ -34,6 +34,14 @@
 # define BOOST_ASIO_OPTION_STORAGE DCB
 #else
 # define BOOST_ASIO_OPTION_STORAGE termios
+#ifdef __VXWORKS__
+struct termios
+      {
+       unsigned int c_cflag;
+       unsigned int tty_iflag;
+       unsigned int BaudRate;
+      };
+#endif
 #endif
 
 #include <boost/asio/detail/push_options.hpp>


### PR DESCRIPTION
This pull updates VxWorks support so all asio tests pass on ARM, IA, PowerPC target systems with both 32bit and 64bit builds with the Clang and GCC compilers currently shipped with VxWorks 7

Also included is serial support. 
Thanks to @dkrejsa for his additions    