### PR TITLE
fix is_buffer_sequence

### DIFF
--- a/include/boost/asio/detail/is_buffer_sequence.hpp
+++ b/include/boost/asio/detail/is_buffer_sequence.hpp
@@ -54,18 +54,21 @@ struct buffer_sequence_memfns_check
 {
 };
 
-template <typename>
-char (&buffer_sequence_begin_helper(...))[2];
-
 #if defined(BOOST_ASIO_HAS_DECLTYPE)
 
+template <typename>
+char buffer_sequence_begin_helper(...);
+
 template <typename T>
-char buffer_sequence_begin_helper(T* t,
+char (&buffer_sequence_begin_helper(T* t,
     typename enable_if<!is_same<
       decltype(boost::asio::buffer_sequence_begin(*t)),
-        void>::value>::type*);
+        void>::value>::type*))[2];
 
 #else // defined(BOOST_ASIO_HAS_DECLTYPE)
+
+template <typename>
+char (&buffer_sequence_begin_helper(...))[2];
 
 template <typename T>
 char buffer_sequence_begin_helper(T* t,
@@ -75,18 +78,21 @@ char buffer_sequence_begin_helper(T* t,
 
 #endif // defined(BOOST_ASIO_HAS_DECLTYPE)
 
-template <typename>
-char (&buffer_sequence_end_helper(...))[2];
-
 #if defined(BOOST_ASIO_HAS_DECLTYPE)
 
+template <typename>
+char buffer_sequence_end_helper(...);
+
 template <typename T>
-char buffer_sequence_end_helper(T* t,
+char (&buffer_sequence_end_helper(T* t,
     typename enable_if<!is_same<
       decltype(boost::asio::buffer_sequence_end(*t)),
-        void>::value>::type*);
+        void>::value>::type*))[2];
 
 #else // defined(BOOST_ASIO_HAS_DECLTYPE)
+
+template <typename>
+char (&buffer_sequence_end_helper(...))[2];
 
 template <typename T>
 char buffer_sequence_end_helper(T* t,
@@ -215,8 +221,8 @@ char mutable_buffers_type_typedef_helper(
 template <typename T, typename Buffer>
 struct is_buffer_sequence_class
   : integral_constant<bool,
-      sizeof(buffer_sequence_begin_helper<T>(0)) != 1 &&
-      sizeof(buffer_sequence_end_helper<T>(0)) != 1 &&
+      sizeof(buffer_sequence_begin_helper<T>(0, 0)) != 1 &&
+      sizeof(buffer_sequence_end_helper<T>(0, 0)) != 1 &&
       sizeof(buffer_sequence_element_type_helper<T, Buffer>(0, 0)) == 1>
 {
 };


### PR DESCRIPTION
Test case:
```
using namespace boost::asio;

struct no_buffers
{
    typedef const_buffer value_type;
    typedef const_buffer* const_iterator;
    const_iterator begin();
};

struct buffers : public no_buffers
{
    const_iterator end();
};

#ifndef BOOST_ASIO_NO_DEPRECATED
static_assert(is_const_buffer_sequence<const_buffers_1>::value == 1, "");
#endif

static_assert(is_const_buffer_sequence<no_buffers>::value == 0, "");
static_assert(is_const_buffer_sequence<buffers>::value == 1, "");
```