### PR TITLE
Possibility to process data between last delimiter and eof while read_until.

### DIFF
--- a/include/boost/asio/impl/read_until.hpp
+++ b/include/boost/asio/impl/read_until.hpp
@@ -885,7 +885,7 @@ namespace detail
           ? error::not_found : ec;
 
         const std::size_t result_n =
-          (ec || search_position_ == not_found)
+          ((ec && ec != boost::asio::error::eof) || search_position_ == not_found)
           ? 0 : search_position_;
 
         handler_(result_ec, result_n);
@@ -1152,7 +1152,7 @@ namespace detail
           ? error::not_found : ec;
 
         const std::size_t result_n =
-          (ec || search_position_ == not_found)
+          ((ec && ec != boost::asio::error::eof) || search_position_ == not_found)
           ? 0 : search_position_;
 
         handler_(result_ec, result_n);
@@ -1427,7 +1427,7 @@ namespace detail
           ? error::not_found : ec;
 
         const std::size_t result_n =
-          (ec || search_position_ == not_found)
+          ((ec && ec != boost::asio::error::eof) || search_position_ == not_found)
           ? 0 : search_position_;
 
         handler_(result_ec, result_n);
@@ -1696,7 +1696,7 @@ namespace detail
           ? error::not_found : ec;
 
         const std::size_t result_n =
-          (ec || search_position_ == not_found)
+          ((ec && ec != boost::asio::error::eof) || search_position_ == not_found)
           ? 0 : search_position_;
 
         handler_(result_ec, result_n);
@@ -2019,7 +2019,7 @@ namespace detail
           ? error::not_found : ec;
 
         const std::size_t result_n =
-          (ec || search_position_ == not_found)
+          ((ec && ec != boost::asio::error::eof) || search_position_ == not_found)
           ? 0 : search_position_;
 
         handler_(result_ec, result_n);
@@ -2292,7 +2292,7 @@ namespace detail
           ? error::not_found : ec;
 
         const std::size_t result_n =
-          (ec || search_position_ == not_found)
+          ((ec && ec != boost::asio::error::eof) || search_position_ == not_found)
           ? 0 : search_position_;
 
         handler_(result_ec, result_n);
@@ -2573,7 +2573,7 @@ namespace detail
           ? error::not_found : ec;
 
         const std::size_t result_n =
-          (ec || search_position_ == not_found)
+          ((ec && ec != boost::asio::error::eof) || search_position_ == not_found)
           ? 0 : search_position_;
 
         handler_(result_ec, result_n);
@@ -2847,7 +2847,7 @@ namespace detail
           ? error::not_found : ec;
 
         const std::size_t result_n =
-          (ec || search_position_ == not_found)
+          ((ec && ec != boost::asio::error::eof) || search_position_ == not_found)
           ? 0 : search_position_;
 
         handler_(result_ec, result_n);


### PR DESCRIPTION
Problem:
If we have some stream of incoming data with structure
<data1><delimeter><data2><delimeter><data3><delimeter><data4><eof>
It's very convinient to use read_until to process such stream. But in current implementation is imposible to process <data4>, becouse in handler value of "bytes_transferred" is always zero when it meet <eof>.
Solution:
With this changes, in case of <eof>, "bytes_transferred" remains unchanged to give posibility to process remains data in handler.