### PR TITLE
cast-function-type MinGW warnings when looking for CancelIoEx

### DIFF
--- a/include/boost/asio/detail/impl/win_iocp_handle_service.ipp
+++ b/include/boost/asio/detail/impl/win_iocp_handle_service.ipp
@@ -243,7 +243,7 @@ boost::system::error_code win_iocp_handle_service::cancel(
   {
     // The version of Windows supports cancellation from any thread.
     typedef BOOL (WINAPI* cancel_io_ex_t)(HANDLE, LPOVERLAPPED);
-    cancel_io_ex_t cancel_io_ex = (cancel_io_ex_t)cancel_io_ex_ptr;
+    cancel_io_ex_t cancel_io_ex = reinterpret_cast<cancel_io_ex_t>(reinterpret_cast<void*>(cancel_io_ex_ptr));
     if (!cancel_io_ex(impl.handle_, 0))
     {
       DWORD last_error = ::GetLastError();

--- a/include/boost/asio/detail/impl/win_iocp_socket_service_base.ipp
+++ b/include/boost/asio/detail/impl/win_iocp_socket_service_base.ipp
@@ -250,7 +250,7 @@ boost::system::error_code win_iocp_socket_service_base::cancel(
   {
     // The version of Windows supports cancellation from any thread.
     typedef BOOL (WINAPI* cancel_io_ex_t)(HANDLE, LPOVERLAPPED);
-    cancel_io_ex_t cancel_io_ex = (cancel_io_ex_t)cancel_io_ex_ptr;
+    cancel_io_ex_t cancel_io_ex = reinterpret_cast<cancel_io_ex_t>(reinterpret_cast<void*>(cancel_io_ex_ptr));
     socket_type sock = impl.socket_;
     HANDLE sock_as_handle = reinterpret_cast<HANDLE>(sock);
     if (!cancel_io_ex(sock_as_handle, 0))


### PR DESCRIPTION
Fixed MinGW warnings about incompatible function cast when looking for entry point of CancelIoEx WinAPI function

Example of warning:

```
include/boost-1_70/boost/asio/detail/impl/win_iocp_socket_service_base.ipp: In member function 'boost::system::error_code boost::asio::detail::win_iocp_socket_service_base::cancel(boost::asio::detail::win_iocp_socket_service_base::base_implementation_type&, boost::system::error_code&)':
include/boost-1_70/boost/asio/detail/impl/win_iocp_socket_service_base.ipp:253:52: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'cancel_io_ex_t' {aka 'int (*)(void*, _OVERLAPPED*)'} [-Wcast-function-type]
     cancel_io_ex_t cancel_io_ex = (cancel_io_ex_t) cancel_io_ex_ptr;
                                                    ^~~~~~~~~~~~~~~~
In file included from include/boost-1_70/boost/asio/detail/win_iocp_socket_service_base.hpp:597,
                 from include/boost-1_70/boost/asio/detail/win_iocp_socket_accept_op.hpp:30,
                 from include/boost-1_70/boost/asio/detail/win_iocp_socket_service.hpp:41,
                 from include/boost-1_70/boost/asio/basic_socket.hpp:34,
                 from include/boost-1_70/boost/asio/basic_datagram_socket.hpp:20,
                 from include/boost-1_70/boost/asio.hpp:24,
```

Reproduced with Boost 1.70.0 and MinGW 8.1.0 from [mingw-w64](https://sourceforge.net/projects/mingw-w64/) project. Used compiler optinos: `-Wall -Wextra -pedantic -Wunused`

This pull request does the same as [pull request #389](https://github.com/chriskohlhoff/asio/pull/389) in [chriskohlhoff/asio](https://github.com/chriskohlhoff/asio) repository.