### PR TITLE
Fix boostorg/asio#231 Windows default serial options on open

### DIFF
--- a/include/boost/asio/detail/impl/win_iocp_serial_port_service.ipp
+++ b/include/boost/asio/detail/impl/win_iocp_serial_port_service.ipp
@@ -82,9 +82,21 @@ boost::system::error_code win_iocp_serial_port_service::open(
   // Set some default serial port parameters. This implementation does not
   // support changing these, so they might as well be in a known state.
   dcb.fBinary = TRUE; // Win32 only supports binary mode.
-  dcb.fDsrSensitivity = FALSE;
   dcb.fNull = FALSE; // Do not ignore NULL characters.
   dcb.fAbortOnError = FALSE; // Ignore serial framing errors.
+  dcb.BaudRate = 0; // 0 baud by default
+  dcb.ByteSize = 8; // 8 bit bytes
+  dcb.fOutxCtsFlow = FALSE; // No flow control
+  dcb.fOutxDsrFlow = FALSE;
+  dcb.fTXContinueOnXoff = TRUE;
+  dcb.fDtrControl = DTR_CONTROL_ENABLE;
+  dcb.fDsrSensitivity = FALSE;
+  dcb.fOutX = FALSE;
+  dcb.fInX = FALSE;
+  dcb.fRtsControl = RTS_CONTROL_ENABLE;
+  dcb.fParity = FALSE; // No parity
+  dcb.Parity = NOPARITY;
+  dcb.StopBits = ONESTOPBIT; // One stop bit
   if (!::SetCommState(handle, &dcb))
   {
     DWORD last_error = ::GetLastError();

--- a/include/boost/asio/detail/impl/win_iocp_serial_port_service.ipp
+++ b/include/boost/asio/detail/impl/win_iocp_serial_port_service.ipp
@@ -88,12 +88,11 @@ boost::system::error_code win_iocp_serial_port_service::open(
   dcb.ByteSize = 8; // 8 bit bytes
   dcb.fOutxCtsFlow = FALSE; // No flow control
   dcb.fOutxDsrFlow = FALSE;
-  dcb.fTXContinueOnXoff = TRUE;
-  dcb.fDtrControl = DTR_CONTROL_ENABLE;
+  dcb.fDtrControl = DTR_CONTROL_DISABLE;
   dcb.fDsrSensitivity = FALSE;
   dcb.fOutX = FALSE;
   dcb.fInX = FALSE;
-  dcb.fRtsControl = RTS_CONTROL_ENABLE;
+  dcb.fRtsControl = DTR_CONTROL_DISABLE;
   dcb.fParity = FALSE; // No parity
   dcb.Parity = NOPARITY;
   dcb.StopBits = ONESTOPBIT; // One stop bit


### PR DESCRIPTION
Sets the defaults for a serial port explicitly on open on the Windows platform to match other platform functionality. Without this, they're inherited from the last use of the port.