### PR TITLE
Add test for "is_xxx_buffer_sequence" templates

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -233,3 +233,7 @@ test-suite "asio" :
   [ run write_at.cpp ]
   [ run write_at.cpp : : : $(USE_SELECT) : write_at_select ]
   ;
+
+test-suite "asio-is_buffer_sequence" :
+  [ run is_buffer_sequence.cpp ]
+  ;

--- a/test/is_buffer_sequence.cpp
+++ b/test/is_buffer_sequence.cpp
@@ -1,0 +1,117 @@
+//
+// is_buffer_sequence.cpp
+// ~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2019 Alexander Karzhenkov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <string>
+#include <boost/asio/buffer.hpp>
+#include "unit_test.hpp"
+
+using namespace boost::asio;
+
+namespace case1 {
+
+struct no_buffers
+{
+  typedef const_buffer value_type;
+  typedef const_buffer* const_iterator;
+  const_iterator begin();
+};
+
+struct buffers : public no_buffers
+{
+  const_iterator end();
+};
+
+void run()
+{
+  BOOST_ASIO_CHECK(is_const_buffer_sequence<no_buffers>::value == 0);
+  BOOST_ASIO_CHECK(is_const_buffer_sequence<buffers>::value == 1);
+}
+
+} // namespace case1
+
+namespace case2 {
+
+#ifdef BOOST_ASIO_HAS_DECLTYPE
+# define DECL_TYPE_MSG "[has decltype] "
+#else
+# define DECL_TYPE_MSG "[has no decltype] "
+#endif
+
+#define TEST_BUFFER_SEQUENCE(Buffer, Condition, Enabled) \
+  test<Buffer, Condition, Enabled>::run(DECL_TYPE_MSG \
+    "test<" #Buffer ", " #Condition ", " #Enabled ">::")
+
+#define DO_CHECK(Name, Expected) \
+  BOOST_ASIO_CHECK_MESSAGE( \
+    Condition<Name>::value == Expected, \
+    msg_prefix + #Name ": " + result[Expected])
+
+const char* result[] = {"false positive", "false negative"};
+
+template <
+  typename Buffer,
+  template <typename> typename Condition,
+  bool Enabled>
+struct test
+{
+  struct typedefs
+  {
+    typedef Buffer value_type;
+    typedef Buffer* const_iterator;
+  };
+
+  struct methods
+  {
+    Buffer* begin();
+    Buffer* end();
+  };
+  
+  struct fake : typedefs
+  {
+    Buffer* begin;
+    Buffer* end;
+  };
+
+  struct incomplete : typedefs
+  {
+    Buffer* begin();
+  };
+
+  struct complete : incomplete
+  {
+    Buffer* end();
+  };
+  
+  static void run(const std::string& msg_prefix)
+  {
+    DO_CHECK(typedefs  , false);
+    DO_CHECK(methods   , false);
+    DO_CHECK(fake      , false);
+    DO_CHECK(incomplete, false);
+    DO_CHECK(complete  , Enabled);
+  }
+};
+
+void run()
+{
+  TEST_BUFFER_SEQUENCE(mutable_buffer, is_mutable_buffer_sequence, true);
+  TEST_BUFFER_SEQUENCE(mutable_buffer, is_const_buffer_sequence  , true);
+  TEST_BUFFER_SEQUENCE(const_buffer  , is_mutable_buffer_sequence, false);
+  TEST_BUFFER_SEQUENCE(const_buffer  , is_const_buffer_sequence  , true);
+}
+
+} // namespace case2
+
+BOOST_ASIO_TEST_SUITE
+(
+  "is_buffer_sequence",
+  BOOST_ASIO_TEST_CASE(case1::run)
+  BOOST_ASIO_TEST_CASE(case2::run)
+)

--- a/test/is_buffer_sequence.cpp
+++ b/test/is_buffer_sequence.cpp
@@ -109,9 +109,29 @@ void run()
 
 } // namespace case2
 
+namespace case3 {
+
+void run()
+{
+    BOOST_ASIO_CHECK(is_mutable_buffer_sequence<void>::value == 0);
+    BOOST_ASIO_CHECK(is_const_buffer_sequence<void>::value == 0);
+
+    BOOST_ASIO_CHECK(is_mutable_buffer_sequence<int>::value == 0);
+    BOOST_ASIO_CHECK(is_const_buffer_sequence<int>::value == 0);
+
+    BOOST_ASIO_CHECK(is_mutable_buffer_sequence<mutable_buffer>::value == 1);
+    BOOST_ASIO_CHECK(is_const_buffer_sequence<mutable_buffer>::value == 1);
+
+    BOOST_ASIO_CHECK(is_mutable_buffer_sequence<const_buffer>::value == 0);
+    BOOST_ASIO_CHECK(is_const_buffer_sequence<const_buffer>::value == 1);
+}
+
+} // namespace case3
+
 BOOST_ASIO_TEST_SUITE
 (
   "is_buffer_sequence",
   BOOST_ASIO_TEST_CASE(case1::run)
   BOOST_ASIO_TEST_CASE(case2::run)
+  BOOST_ASIO_TEST_CASE(case3::run)
 )


### PR DESCRIPTION
It seems the templates `is_mutable_buffer_sequence` and `is_const_buffer_sequence` are not working as intended. Proposed test will fail; the set of failed checks varies depending on the availability of `decltype`.

The first test case is borrowed from PR #218; some other combinations of declarations in the inspected type are added. PR #218 fixes some failed checks, but not all.