### PR TITLE
fix is_buffer_sequence (yet another variant)

### DIFF
--- a/include/boost/asio/detail/is_buffer_sequence.hpp
+++ b/include/boost/asio/detail/is_buffer_sequence.hpp
@@ -3,6 +3,7 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
 // Copyright (c) 2003-2019 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+// Copyright (c) 2019 Alexander Karzhenkov
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -28,204 +29,71 @@ class const_buffer;
 
 namespace detail {
 
-struct buffer_sequence_memfns_base
-{
-  void begin();
-  void end();
-  void size();
-  void max_size();
-  void capacity();
-  void data();
-  void prepare();
-  void commit();
-  void consume();
-  void grow();
-  void shrink();
-};
-
-template <typename T>
-struct buffer_sequence_memfns_derived
-  : T, buffer_sequence_memfns_base
-{
-};
-
-template <typename T, T>
-struct buffer_sequence_memfns_check
-{
-};
-
-template <typename>
-char (&buffer_sequence_begin_helper(...))[2];
-
-#if defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename T>
-char buffer_sequence_begin_helper(T* t,
-    typename enable_if<!is_same<
-      decltype(boost::asio::buffer_sequence_begin(*t)),
-        void>::value>::type*);
-
-#else // defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename T>
-char buffer_sequence_begin_helper(T* t,
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::begin>*);
-
-#endif // defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename>
-char (&buffer_sequence_end_helper(...))[2];
-
-#if defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename T>
-char buffer_sequence_end_helper(T* t,
-    typename enable_if<!is_same<
-      decltype(boost::asio::buffer_sequence_end(*t)),
-        void>::value>::type*);
-
-#else // defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename T>
-char buffer_sequence_end_helper(T* t,
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::end>*);
-
-#endif // defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename>
-char (&size_memfn_helper(...))[2];
-
-template <typename T>
-char size_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::size>*);
-
-template <typename>
-char (&max_size_memfn_helper(...))[2];
-
-template <typename T>
-char max_size_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::max_size>*);
-
-template <typename>
-char (&capacity_memfn_helper(...))[2];
-
-template <typename T>
-char capacity_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::capacity>*);
-
-template <typename>
-char (&data_memfn_helper(...))[2];
-
-template <typename T>
-char data_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::data>*);
-
-template <typename>
-char (&prepare_memfn_helper(...))[2];
-
-template <typename T>
-char prepare_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::prepare>*);
-
-template <typename>
-char (&commit_memfn_helper(...))[2];
-
-template <typename T>
-char commit_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::commit>*);
-
-template <typename>
-char (&consume_memfn_helper(...))[2];
-
-template <typename T>
-char consume_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::consume>*);
-
-template <typename>
-char (&grow_memfn_helper(...))[2];
-
-template <typename T>
-char grow_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::grow>*);
-
-template <typename>
-char (&shrink_memfn_helper(...))[2];
-
-template <typename T>
-char shrink_memfn_helper(
-    buffer_sequence_memfns_check<
-      void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::shrink>*);
-
-template <typename, typename>
-char (&buffer_sequence_element_type_helper(...))[2];
-
-#if defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename T, typename Buffer>
-char buffer_sequence_element_type_helper(T* t,
-    typename enable_if<is_convertible<
-      decltype(*boost::asio::buffer_sequence_begin(*t)),
-        Buffer>::value>::type*);
-
-#else // defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename T, typename Buffer>
-char buffer_sequence_element_type_helper(
-    typename T::const_iterator*,
-    typename enable_if<is_convertible<
-      typename T::value_type, Buffer>::value>::type*);
-
-#endif // defined(BOOST_ASIO_HAS_DECLTYPE)
-
-template <typename>
-char (&const_buffers_type_typedef_helper(...))[2];
-
-template <typename T>
-char const_buffers_type_typedef_helper(
-    typename T::const_buffers_type*);
-
-template <typename>
-char (&mutable_buffers_type_typedef_helper(...))[2];
-
-template <typename T>
-char mutable_buffers_type_typedef_helper(
-    typename T::mutable_buffers_type*);
-
-template <typename T, typename Buffer>
-struct is_buffer_sequence_class
+template <typename C, typename T>
+struct buffer_sequence_check
   : integral_constant<bool,
-      sizeof(buffer_sequence_begin_helper<T>(0)) != 1 &&
-      sizeof(buffer_sequence_end_helper<T>(0)) != 1 &&
-      sizeof(buffer_sequence_element_type_helper<T, Buffer>(0, 0)) == 1>
+      sizeof(C::template detector<T>(0)) == 1>
 {
+};
+
+struct buffer_sequence_helper
+{
+  template <int N> struct result { };
+
+  template <typename>
+  static char (&detector(...))[2];
+
+  template <typename T>
+  static typename enable_if<
+    is_member_function_pointer<T>::value>::type
+  is_memfn(T);
+
+  template <typename To, typename From>
+  static typename enable_if<
+    is_convertible<From, To>::value>::type
+  is_convertible_to(From);
+
+  template <typename T>
+  static void check();
+};
+
+template <typename Buffer>
+struct is_buffer_sequence_class : buffer_sequence_helper
+{
+  using buffer_sequence_helper::detector;
+
+  template <typename T>
+  static result<sizeof(
+
+    // Basic checks
+
+    is_convertible_to<Buffer>(*buffer_sequence_begin(declval<T&>())),
+    is_convertible_to<Buffer>(*buffer_sequence_end(declval<T&>())),
+
+#if 1
+
+    // Check additional details of the inspected type
+
+    // Perhaps the additional checks make sense when using C++98.
+    // It would be better to implement them by the means
+    // of 'buffer_sequence_begin' and 'buffer_sequence_end'
+    // (or simply to remove).
+
+    is_convertible_to<Buffer>(*declval<T>().begin()),
+    is_convertible_to<Buffer>(*declval<T>().end()),
+
+    is_convertible_to<Buffer>(declval<typename T::value_type>()),
+
+    check<typename T::const_iterator>(),
+
+#endif
+
+  0)> detector(int);
 };
 
 template <typename T, typename Buffer>
 struct is_buffer_sequence
-  : conditional<is_class<T>::value,
-      is_buffer_sequence_class<T, Buffer>,
-      false_type>::type
+  : buffer_sequence_check<is_buffer_sequence_class<Buffer>, T>
 {
 };
 
@@ -253,49 +121,57 @@ struct is_buffer_sequence<const_buffer, mutable_buffer>
 {
 };
 
-template <typename T>
-struct is_dynamic_buffer_class_v1
-  : integral_constant<bool,
-      sizeof(size_memfn_helper<T>(0)) != 1 &&
-      sizeof(max_size_memfn_helper<T>(0)) != 1 &&
-      sizeof(capacity_memfn_helper<T>(0)) != 1 &&
-      sizeof(data_memfn_helper<T>(0)) != 1 &&
-      sizeof(consume_memfn_helper<T>(0)) != 1 &&
-      sizeof(prepare_memfn_helper<T>(0)) != 1 &&
-      sizeof(commit_memfn_helper<T>(0)) != 1 &&
-      sizeof(const_buffers_type_typedef_helper<T>(0)) == 1 &&
-      sizeof(mutable_buffers_type_typedef_helper<T>(0)) == 1>
+struct is_dynamic_buffer_class_v1 : buffer_sequence_helper
 {
+  using buffer_sequence_helper::detector;
+
+  template <typename T, typename Buffer>
+  static result<sizeof(
+
+    is_memfn(&T::size),
+    is_memfn(&T::max_size),
+    is_memfn(&T::capacity),
+    is_memfn(&T::data),
+    is_memfn(&T::consume),
+    is_memfn(&T::prepare),
+    is_memfn(&T::commit),
+
+    check<typename T::const_buffers_type>(),
+    check<typename T::mutable_buffers_type>(),
+
+  0)> detector(int);
 };
 
 template <typename T>
 struct is_dynamic_buffer_v1
-  : conditional<is_class<T>::value,
-      is_dynamic_buffer_class_v1<T>,
-      false_type>::type
+  : buffer_sequence_check<is_dynamic_buffer_class_v1, T>
 {
 };
 
-template <typename T>
-struct is_dynamic_buffer_class_v2
-  : integral_constant<bool,
-      sizeof(size_memfn_helper<T>(0)) != 1 &&
-      sizeof(max_size_memfn_helper<T>(0)) != 1 &&
-      sizeof(capacity_memfn_helper<T>(0)) != 1 &&
-      sizeof(data_memfn_helper<T>(0)) != 1 &&
-      sizeof(consume_memfn_helper<T>(0)) != 1 &&
-      sizeof(grow_memfn_helper<T>(0)) != 1 &&
-      sizeof(shrink_memfn_helper<T>(0)) != 1 &&
-      sizeof(const_buffers_type_typedef_helper<T>(0)) == 1 &&
-      sizeof(mutable_buffers_type_typedef_helper<T>(0)) == 1>
+struct is_dynamic_buffer_class_v2 : buffer_sequence_helper
 {
+  using buffer_sequence_helper::detector;
+
+  template <typename T, typename Buffer>
+  static result<sizeof(
+
+    is_memfn(&T::size),
+    is_memfn(&T::max_size),
+    is_memfn(&T::capacity),
+    is_memfn(&T::data),
+    is_memfn(&T::consume),
+    is_memfn(&T::grow),
+    is_memfn(&T::shrink),
+
+    check<typename T::const_buffers_type>(),
+    check<typename T::mutable_buffers_type>(),
+
+  0)> detector(int);
 };
 
 template <typename T>
 struct is_dynamic_buffer_v2
-  : conditional<is_class<T>::value,
-      is_dynamic_buffer_class_v2<T>,
-      false_type>::type
+  : buffer_sequence_check<is_dynamic_buffer_class_v2, T>
 {
 };
 

--- a/include/boost/asio/detail/type_traits.hpp
+++ b/include/boost/asio/detail/type_traits.hpp
@@ -23,12 +23,14 @@
 # include <boost/type_traits/add_const.hpp>
 # include <boost/type_traits/conditional.hpp>
 # include <boost/type_traits/decay.hpp>
+# include <boost/type_traits/declval.hpp>
 # include <boost/type_traits/integral_constant.hpp>
 # include <boost/type_traits/is_base_of.hpp>
 # include <boost/type_traits/is_class.hpp>
 # include <boost/type_traits/is_const.hpp>
 # include <boost/type_traits/is_convertible.hpp>
 # include <boost/type_traits/is_function.hpp>
+# include <boost/type_traits/is_member_function_pointer.hpp>
 # include <boost/type_traits/is_same.hpp>
 # include <boost/type_traits/remove_pointer.hpp>
 # include <boost/type_traits/remove_reference.hpp>
@@ -43,6 +45,7 @@ namespace asio {
 using std::add_const;
 using std::conditional;
 using std::decay;
+using std::declval;
 using std::enable_if;
 using std::false_type;
 using std::integral_constant;
@@ -51,6 +54,7 @@ using std::is_class;
 using std::is_const;
 using std::is_convertible;
 using std::is_function;
+using std::is_member_function_pointer;
 using std::is_same;
 using std::remove_pointer;
 using std::remove_reference;
@@ -68,6 +72,7 @@ template <bool Condition, typename Type = void>
 struct enable_if : boost::enable_if_c<Condition, Type> {};
 using boost::conditional;
 using boost::decay;
+using boost::declval;
 using boost::false_type;
 using boost::integral_constant;
 using boost::is_base_of;
@@ -75,6 +80,7 @@ using boost::is_class;
 using boost::is_const;
 using boost::is_convertible;
 using boost::is_function;
+using boost::is_member_function_pointer;
 using boost::is_same;
 using boost::remove_pointer;
 using boost::remove_reference;


### PR DESCRIPTION
Here is reworked variant of `is_buffer_sequence`. It is more concise than the original, since it does not introduce several helper declarations for each individual check. This variant solves the issue described in PR #218 and satisfies the test proposed in PR #253.

Some additional changes may be also considered. Perhaps a bit more consistent approach is to check only return types of `buffer_sequence_begin` and `buffer_sequence_end` template functions and to exclude other checks (see 8cd7ba9b9e07171d4c1628b101469962bc330f81). This allows to use any class having corresponding specializations of these templates as a buffer sequence. Such a classes are, for example `mutable_buffer` and `const_buffer`. They would not need the individual specializations of `is_buffer_sequence` class template.

However, the commit 8cd7ba9b9e07171d4c1628b101469962bc330f81 causes the test from PR #253 to fail with several "false positives". Probably the test needs to be revisited (relaxed).