### PR TITLE
Preliminary PR - use zero copy SSL API

### DIFF
--- a/include/boost/asio/ssl/detail/engine.hpp
+++ b/include/boost/asio/ssl/detail/engine.hpp
@@ -97,6 +97,9 @@ public:
   BOOST_ASIO_DECL boost::asio::mutable_buffer get_output(
       const boost::asio::mutable_buffer& data);
 
+  // Get 0-copy access to the underlying output buffer that should be written to the transport.
+  BOOST_ASIO_DECL boost::asio::const_buffer get_output0(boost::system::error_code& ec);
+
   // Put input data that was read from the transport.
   BOOST_ASIO_DECL boost::asio::const_buffer put_input(
       const boost::asio::const_buffer& data);

--- a/include/boost/asio/ssl/detail/impl/engine.ipp
+++ b/include/boost/asio/ssl/detail/impl/engine.ipp
@@ -178,6 +178,22 @@ boost::asio::mutable_buffer engine::get_output(
       length > 0 ? static_cast<std::size_t>(length) : 0);
 }
 
+boost::asio::const_buffer engine::get_output0(boost::system::error_code& ec) {
+  char* ptr = NULL;
+
+  int res = ::BIO_nread(ext_bio_, &ptr, OSSL_SSIZE_MAX);
+  if (res < 0)
+  {
+    unsigned long sys_error = ::ERR_get_error();
+    ec = boost::system::error_code(sys_error,
+        boost::asio::error::get_ssl_category());
+
+    return boost::asio::const_buffer();
+  }
+
+  return boost::asio::const_buffer(ptr, res);
+}
+
 boost::asio::const_buffer engine::put_input(
     const boost::asio::const_buffer& data)
 {

--- a/include/boost/asio/ssl/detail/io.hpp
+++ b/include/boost/asio/ssl/detail/io.hpp
@@ -34,6 +34,8 @@ std::size_t io(Stream& next_layer, stream_core& core,
 {
   boost::system::error_code io_ec;
   std::size_t bytes_transferred = 0;
+  boost::asio::const_buffer out_buf;
+
   do switch (op(core.engine_, ec, bytes_transferred))
   {
   case engine::want_input_and_retry:
@@ -58,8 +60,10 @@ std::size_t io(Stream& next_layer, stream_core& core,
 
     // Get output data from the engine and write it to the underlying
     // transport.
-    boost::asio::write(next_layer,
-        core.engine_.get_output(core.output_buffer_), io_ec);
+    out_buf = core.engine_.get_output0(io_ec);
+    if (!io_ec) {
+      boost::asio::write(next_layer, out_buf, io_ec);
+    }
     if (!ec)
       ec = io_ec;
 
@@ -70,8 +74,10 @@ std::size_t io(Stream& next_layer, stream_core& core,
 
     // Get output data from the engine and write it to the underlying
     // transport.
-    boost::asio::write(next_layer,
-        core.engine_.get_output(core.output_buffer_), io_ec);
+    out_buf = core.engine_.get_output0(io_ec);
+    if (!io_ec) {
+      boost::asio::write(next_layer, out_buf, io_ec);
+    }
     if (!ec)
       ec = io_ec;
 


### PR DESCRIPTION
Using zero-copy API in order to move data between SSL buffers and the transport layer.

I would like to hear the opinion from maintainers whether to continue with this.