### PR TITLE
Fix io_context::notify_fork breaking ip resolver

### DIFF
--- a/include/boost/asio/detail/impl/resolver_service_base.ipp
+++ b/include/boost/asio/detail/impl/resolver_service_base.ipp
@@ -81,12 +81,12 @@ void resolver_service_base::base_notify_fork(
       work_thread_->join();
       work_thread_.reset();
     }
-    else
-    {
-      work_scheduler_->restart();
-      work_thread_.reset(new boost::asio::detail::thread(
-            work_scheduler_runner(*work_scheduler_)));
-    }
+  }
+  else if (fork_ev != execution_context::fork_prepare)
+  {
+    work_scheduler_->restart();
+    work_thread_.reset(new boost::asio::detail::thread(
+          work_scheduler_runner(*work_scheduler_)));
   }
 }
 


### PR DESCRIPTION
Consider following example:
```
#include <iostream>
#include <stdexcept>
#include <memory>

#include <boost/asio.hpp>

#include <unistd.h>

namespace ba = boost::asio;

std::unique_ptr< ba::io_context > ioc;
std::unique_ptr< ba::ip::tcp::resolver > resolver;
bool is_first = true;

void do_cycle();

void handle_resolve(const boost::system::error_code &ec, const ba::ip::tcp::resolver::results_type & results)
{
    if (ec)
        throw std::runtime_error("Resolve: "  + ec.message());

    if (is_first)
    {
        std::cout << "Resolved once" << std::endl;

        is_first = false;

        ioc->notify_fork(ba::io_context::fork_prepare);

        std::cout << "Forking" << std::endl;
        if (fork() == 0)
        {
            setsid();
            ioc->notify_fork(ba::io_context::fork_child);
            do_cycle();
        }
        else
        {
            ioc->notify_fork(ba::io_context::fork_parent);
            ioc->stop();
        }
    }
    else
    {
        std::cout << "Resolved twice" << std::endl;
    }
};

void do_cycle()
{
    std::cout << "Resolving " << getpid() << std::endl;
    resolver->async_resolve(ba::ip::tcp::resolver::query("www.boost.org", "http"), &handle_resolve);
};


int main()
{
    ioc = std::make_unique< ba::io_context >();
    resolver = std::make_unique< ba::ip::tcp::resolver >(*ioc);

    do_cycle();
    ioc->run();

    return 0;
}
```
Second `async_resolve` never starts. First `io_context::notify_fork` stops `resolver_service_base`'s internal scheduler. Following calls to `io_context::notify_fork` don't reset it what breaks every resolver associated with a context.