### PR TITLE
Fix strand move constructor strand(strand<OtherExecutor>&& other)

### DIFF
--- a/include/boost/asio/strand.hpp
+++ b/include/boost/asio/strand.hpp
@@ -28,6 +28,8 @@ namespace asio {
 template <typename Executor>
 class strand
 {
+template <typename OtherExecutor>
+friend class strand<OtherExecutor>;
 public:
   /// The type of the underlying executor.
   typedef Executor inner_executor_type;
@@ -109,7 +111,7 @@ public:
    */
   template <class OtherExecutor>
   strand(strand<OtherExecutor>&& other) BOOST_ASIO_NOEXCEPT
-    : executor_(BOOST_ASIO_MOVE_CAST(OtherExecutor)(other)),
+    : executor_(BOOST_ASIO_MOVE_CAST(OtherExecutor)(other.executor_)),
       impl_(BOOST_ASIO_MOVE_CAST(implementation_type)(other.impl_))
   {
   }


### PR DESCRIPTION
The `strand::strand(strand<OtherExecutor>&& other)` move constructor is broken as it tries to do an invalid cast on the wrong object. A `friend` declaration is also required to access the private members of the other `strand`. This PR should fix that.