### PR TITLE
Disable -Wnon-virtual-dtor for classes derived from boost::system::error_category

### DIFF
--- a/include/boost/asio/impl/error.ipp
+++ b/include/boost/asio/impl/error.ipp
@@ -27,6 +27,12 @@ namespace error {
 
 #if !defined(BOOST_ASIO_WINDOWS) && !defined(__CYGWIN__)
 
+// classes derived from boost::system::error_category
+#if ( defined( BOOST_GCC ) && BOOST_GCC >= 40600 ) || defined( BOOST_CLANG )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
+
 namespace detail {
 
 class netdb_category : public boost::system::error_category
@@ -114,6 +120,10 @@ public:
 };
 
 } // namespace detail
+
+#if ( defined( BOOST_GCC ) && BOOST_GCC >= 40600 ) || defined( BOOST_CLANG )
+#pragma GCC diagnostic pop
+#endif
 
 const boost::system::error_category& get_misc_category()
 {


### PR DESCRIPTION
Compiler warnings for non-virtual destructors are disabled for boost::system::error_category but the issue also affects all derived classes.
```
  error: base class ‘class boost::system::error_category’ has accessible non-virtual destructor [-Werror=non-virtual-dtor]
   class netdb_category : public boost::system::error_category
         ^~~~~~~~~~~~~~
  error: ‘class boost::asio::error::detail::netdb_category’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]

  error: base class ‘class boost::system::error_category’ has accessible non-virtual destructor [-Werror=non-virtual-dtor]
   class addrinfo_category : public boost::system::error_category
         ^~~~~~~~~~~~~~~~~
  error: ‘class boost::asio::error::detail::addrinfo_category’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]

  error: base class ‘class boost::system::error_category’ has accessible non-virtual destructor [-Werror=non-virtual-dtor]
   class misc_category : public boost::system::error_category
         ^~~~~~~~~~~~~
  error: ‘class boost::asio::error::detail::misc_category’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
```
Disable -Wnon-virtual-dtor in the same way that Boost.System does.