### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/asio/detail/epoll_reactor.hpp
+++ b/include/boost/asio/detail/epoll_reactor.hpp
@@ -86,14 +86,14 @@ public:
   BOOST_ASIO_DECL epoll_reactor(boost::asio::execution_context& ctx);
 
   // Destructor.
-  BOOST_ASIO_DECL ~epoll_reactor();
+  BOOST_ASIO_DECL ~epoll_reactor() BOOST_OVERRIDE;
 
   // Destroy all user-defined handler objects owned by the service.
-  BOOST_ASIO_DECL void shutdown();
+  BOOST_ASIO_DECL void shutdown() BOOST_OVERRIDE;
 
   // Recreate internal descriptors following a fork.
   BOOST_ASIO_DECL void notify_fork(
-      boost::asio::execution_context::fork_event fork_ev);
+      boost::asio::execution_context::fork_event fork_ev) BOOST_OVERRIDE;
 
   // Initialise the task.
   BOOST_ASIO_DECL void init_task();

--- a/include/boost/asio/detail/posix_thread.hpp
+++ b/include/boost/asio/detail/posix_thread.hpp
@@ -81,7 +81,7 @@ private:
     {
     }
 
-    virtual void run()
+    void run() BOOST_OVERRIDE
     {
       f_();
     }

--- a/include/boost/asio/detail/reactive_socket_service.hpp
+++ b/include/boost/asio/detail/reactive_socket_service.hpp
@@ -82,7 +82,7 @@ public:
   }
 
   // Destroy all user-defined handler objects owned by the service.
-  void shutdown()
+  void shutdown() BOOST_OVERRIDE
   {
     this->base_shutdown();
   }

--- a/include/boost/asio/detail/resolver_service.hpp
+++ b/include/boost/asio/detail/resolver_service.hpp
@@ -60,13 +60,13 @@ public:
   }
 
   // Destroy all user-defined handler objects owned by the service.
-  void shutdown()
+  void shutdown() BOOST_OVERRIDE
   {
     this->base_shutdown();
   }
 
   // Perform any fork-related housekeeping.
-  void notify_fork(execution_context::fork_event fork_ev)
+  void notify_fork(execution_context::fork_event fork_ev) BOOST_OVERRIDE
   {
     this->base_notify_fork(fork_ev);
   }

--- a/include/boost/asio/detail/scheduler.hpp
+++ b/include/boost/asio/detail/scheduler.hpp
@@ -49,10 +49,10 @@ public:
       int concurrency_hint = 0, bool own_thread = true);
 
   // Destructor.
-  BOOST_ASIO_DECL ~scheduler();
+  BOOST_ASIO_DECL ~scheduler() BOOST_OVERRIDE;
 
   // Destroy all user-defined handler objects owned by the service.
-  BOOST_ASIO_DECL void shutdown();
+  BOOST_ASIO_DECL void shutdown() BOOST_OVERRIDE;
 
   // Initialise the task, if required.
   BOOST_ASIO_DECL void init_task();

--- a/include/boost/asio/executor.hpp
+++ b/include/boost/asio/executor.hpp
@@ -36,8 +36,8 @@ public:
   BOOST_ASIO_DECL bad_executor() BOOST_ASIO_NOEXCEPT;
 
   /// Obtain message associated with exception.
-  BOOST_ASIO_DECL virtual const char* what() const
-    BOOST_ASIO_NOEXCEPT_OR_NOTHROW;
+  BOOST_ASIO_DECL const char* what() const
+    BOOST_ASIO_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE;
 };
 
 /// Polymorphic wrapper for executors.

--- a/include/boost/asio/impl/error.ipp
+++ b/include/boost/asio/impl/error.ipp
@@ -32,12 +32,12 @@ namespace detail {
 class netdb_category : public boost::system::error_category
 {
 public:
-  const char* name() const BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT
+  const char* name() const BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT BOOST_OVERRIDE
   {
     return "asio.netdb";
   }
 
-  std::string message(int value) const
+  std::string message(int value) const BOOST_OVERRIDE
   {
     if (value == error::host_not_found)
       return "Host not found (authoritative)";
@@ -64,12 +64,12 @@ namespace detail {
 class addrinfo_category : public boost::system::error_category
 {
 public:
-  const char* name() const BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT
+  const char* name() const BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT BOOST_OVERRIDE
   {
     return "asio.addrinfo";
   }
 
-  std::string message(int value) const
+  std::string message(int value) const BOOST_OVERRIDE
   {
     if (value == error::service_not_found)
       return "Service not found";
@@ -94,12 +94,12 @@ namespace detail {
 class misc_category : public boost::system::error_category
 {
 public:
-  const char* name() const BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT
+  const char* name() const BOOST_ASIO_ERROR_CATEGORY_NOEXCEPT BOOST_OVERRIDE
   {
     return "asio.misc";
   }
 
-  std::string message(int value) const
+  std::string message(int value) const BOOST_OVERRIDE
   {
     if (value == error::already_open)
       return "Already open";

--- a/include/boost/asio/impl/executor.hpp
+++ b/include/boost/asio/impl/executor.hpp
@@ -147,13 +147,13 @@ public:
   {
   }
 
-  impl_base* clone() const BOOST_ASIO_NOEXCEPT
+  impl_base* clone() const BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     ++ref_count_;
     return const_cast<impl_base*>(static_cast<const impl_base*>(this));
   }
 
-  void destroy() BOOST_ASIO_NOEXCEPT
+  void destroy() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     if (--ref_count_ == 0)
     {
@@ -164,52 +164,52 @@ public:
     }
   }
 
-  void on_work_started() BOOST_ASIO_NOEXCEPT
+  void on_work_started() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     executor_.on_work_started();
   }
 
-  void on_work_finished() BOOST_ASIO_NOEXCEPT
+  void on_work_finished() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     executor_.on_work_finished();
   }
 
-  execution_context& context() BOOST_ASIO_NOEXCEPT
+  execution_context& context() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return executor_.context();
   }
 
-  void dispatch(BOOST_ASIO_MOVE_ARG(function) f)
+  void dispatch(BOOST_ASIO_MOVE_ARG(function) f) BOOST_OVERRIDE
   {
     executor_.dispatch(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
   }
 
-  void post(BOOST_ASIO_MOVE_ARG(function) f)
+  void post(BOOST_ASIO_MOVE_ARG(function) f) BOOST_OVERRIDE
   {
     executor_.post(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
   }
 
-  void defer(BOOST_ASIO_MOVE_ARG(function) f)
+  void defer(BOOST_ASIO_MOVE_ARG(function) f) BOOST_OVERRIDE
   {
     executor_.defer(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
   }
 
-  type_id_result_type target_type() const BOOST_ASIO_NOEXCEPT
+  type_id_result_type target_type() const BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return type_id<Executor>();
   }
 
-  void* target() BOOST_ASIO_NOEXCEPT
+  void* target() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return &executor_;
   }
 
-  const void* target() const BOOST_ASIO_NOEXCEPT
+  const void* target() const BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return &executor_;
   }
 
-  bool equals(const impl_base* e) const BOOST_ASIO_NOEXCEPT
+  bool equals(const impl_base* e) const BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     if (this == e)
       return true;
@@ -247,7 +247,7 @@ private:
   };
 };
 
-// Polymorphic allocator specialisation for system_executor.
+// Polymorphic allocator specialization for system_executor.
 template <typename Allocator>
 class executor::impl<system_executor, Allocator>
   : public executor::impl_base
@@ -264,61 +264,61 @@ public:
   {
   }
 
-  impl_base* clone() const BOOST_ASIO_NOEXCEPT
+  impl_base* clone() const BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return const_cast<impl_base*>(static_cast<const impl_base*>(this));
   }
 
-  void destroy() BOOST_ASIO_NOEXCEPT
+  void destroy() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
   }
 
-  void on_work_started() BOOST_ASIO_NOEXCEPT
+  void on_work_started() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     executor_.on_work_started();
   }
 
-  void on_work_finished() BOOST_ASIO_NOEXCEPT
+  void on_work_finished() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     executor_.on_work_finished();
   }
 
-  execution_context& context() BOOST_ASIO_NOEXCEPT
+  execution_context& context() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return executor_.context();
   }
 
-  void dispatch(BOOST_ASIO_MOVE_ARG(function) f)
+  void dispatch(BOOST_ASIO_MOVE_ARG(function) f) BOOST_OVERRIDE
   {
     executor_.dispatch(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
   }
 
-  void post(BOOST_ASIO_MOVE_ARG(function) f)
+  void post(BOOST_ASIO_MOVE_ARG(function) f) BOOST_OVERRIDE
   {
     executor_.post(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
   }
 
-  void defer(BOOST_ASIO_MOVE_ARG(function) f)
+  void defer(BOOST_ASIO_MOVE_ARG(function) f) BOOST_OVERRIDE
   {
     executor_.defer(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
   }
 
-  type_id_result_type target_type() const BOOST_ASIO_NOEXCEPT
+  type_id_result_type target_type() const BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return type_id<system_executor>();
   }
 
-  void* target() BOOST_ASIO_NOEXCEPT
+  void* target() BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return &executor_;
   }
 
-  const void* target() const BOOST_ASIO_NOEXCEPT
+  const void* target() const BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return &executor_;
   }
 
-  bool equals(const impl_base* e) const BOOST_ASIO_NOEXCEPT
+  bool equals(const impl_base* e) const BOOST_ASIO_NOEXCEPT BOOST_OVERRIDE
   {
     return this == e;
   }

--- a/include/boost/asio/io_context.hpp
+++ b/include/boost/asio/io_context.hpp
@@ -272,7 +272,7 @@ public:
    * @note Calling the run() function from a thread that is currently calling
    * one of run(), run_one(), run_for(), run_until(), poll() or poll_one() on
    * the same io_context object may introduce the potential for deadlock. It is
-   * the caller's reponsibility to avoid this.
+   * the caller's responsibility to avoid this.
    *
    * The poll() function may also be used to dispatch ready handlers, but
    * without blocking.
@@ -303,7 +303,7 @@ public:
    * @note Calling the run() function from a thread that is currently calling
    * one of run(), run_one(), run_for(), run_until(), poll() or poll_one() on
    * the same io_context object may introduce the potential for deadlock. It is
-   * the caller's reponsibility to avoid this.
+   * the caller's responsibility to avoid this.
    *
    * The poll() function may also be used to dispatch ready handlers, but
    * without blocking.
@@ -355,12 +355,12 @@ public:
    * @note Calling the run_one() function from a thread that is currently
    * calling one of run(), run_one(), run_for(), run_until(), poll() or
    * poll_one() on the same io_context object may introduce the potential for
-   * deadlock. It is the caller's reponsibility to avoid this.
+   * deadlock. It is the caller's responsibility to avoid this.
    */
   BOOST_ASIO_DECL count_type run_one();
 
 #if !defined(BOOST_ASIO_NO_DEPRECATED)
-  /// (Deprecated: Use non-error_code overlaod.) Run the io_context object's
+  /// (Deprecated: Use non-error_code overload.) Run the io_context object's
   /// event processing loop to execute at most one handler.
   /**
    * The run_one() function blocks until one handler has been dispatched, or
@@ -377,7 +377,7 @@ public:
    * @note Calling the run_one() function from a thread that is currently
    * calling one of run(), run_one(), run_for(), run_until(), poll() or
    * poll_one() on the same io_context object may introduce the potential for
-   * deadlock. It is the caller's reponsibility to avoid this.
+   * deadlock. It is the caller's responsibility to avoid this.
    */
   BOOST_ASIO_DECL count_type run_one(boost::system::error_code& ec);
 #endif // !defined(BOOST_ASIO_NO_DEPRECATED)
@@ -793,7 +793,7 @@ public:
 
 private:
   /// Destroy all user-defined handler objects owned by the service.
-  BOOST_ASIO_DECL virtual void shutdown();
+  BOOST_ASIO_DECL void shutdown() BOOST_OVERRIDE;
 
 #if !defined(BOOST_ASIO_NO_DEPRECATED)
   /// (Deprecated: Use shutdown().) Destroy all user-defined handler objects
@@ -807,8 +807,8 @@ private:
    * This function is not a pure virtual so that services only have to
    * implement it if necessary. The default implementation does nothing.
    */
-  BOOST_ASIO_DECL virtual void notify_fork(
-      execution_context::fork_event event);
+  BOOST_ASIO_DECL void notify_fork(
+      execution_context::fork_event event) BOOST_OVERRIDE;
 
 #if !defined(BOOST_ASIO_NO_DEPRECATED)
   /// (Deprecated: Use notify_fork().) Handle notification of a fork-related
@@ -829,7 +829,7 @@ protected:
   BOOST_ASIO_DECL service(boost::asio::io_context& owner);
 
   /// Destructor.
-  BOOST_ASIO_DECL virtual ~service();
+  BOOST_ASIO_DECL ~service() BOOST_OVERRIDE;
 };
 
 namespace detail {

--- a/include/boost/asio/ip/bad_address_cast.hpp
+++ b/include/boost/asio/ip/bad_address_cast.hpp
@@ -37,10 +37,10 @@ public:
   bad_address_cast() {}
 
   /// Destructor.
-  virtual ~bad_address_cast() BOOST_ASIO_NOEXCEPT_OR_NOTHROW {}
+  ~bad_address_cast() BOOST_ASIO_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {}
 
   /// Get the message associated with the exception.
-  virtual const char* what() const BOOST_ASIO_NOEXCEPT_OR_NOTHROW
+  const char* what() const BOOST_ASIO_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
   {
     return "bad address cast";
   }


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.

Also fix some misspellings in comments.