### PR TITLE
Fix race condition where child leaks signal to parent

### DIFF
--- a/include/boost/asio/detail/impl/signal_set_service.ipp
+++ b/include/boost/asio/detail/impl/signal_set_service.ipp
@@ -42,6 +42,14 @@ struct signal_state
   // The write end of the pipe used for signal notifications.
   int write_descriptor_;
 
+#if !defined(BOOST_ASIO_WINDOWS) \
+  && !defined(BOOST_ASIO_WINDOWS_RUNTIME) \
+  && !defined(__CYGWIN__)
+  // Our own PID. We need it so we can detect if we had recently
+  // fork()'ed but not yet been notified.
+  pid_t pid_;
+#endif
+
   // Whether the signal state has been prepared for a fork.
   bool fork_prepared_;
 
@@ -55,7 +63,13 @@ struct signal_state
 signal_state* get_signal_state()
 {
   static signal_state state = {
-    BOOST_ASIO_STATIC_MUTEX_INIT, -1, -1, false, 0, { 0 } };
+    BOOST_ASIO_STATIC_MUTEX_INIT, -1, -1,
+#if !defined(BOOST_ASIO_WINDOWS) \
+  && !defined(BOOST_ASIO_WINDOWS_RUNTIME) \
+  && !defined(__CYGWIN__)
+    ::getpid(),
+#endif
+    false, 0, { 0 } };
   return &state;
 }
 
@@ -70,6 +84,18 @@ void boost_asio_signal_handler(int signal_number)
       //   || defined(__CYGWIN__)
   int saved_errno = errno;
   signal_state* state = get_signal_state();
+  pid_t pid = ::getpid();
+  if (state->pid_ != pid)
+  {
+    // There is a small window between ::fork() and notify_fork() where
+    // we need to make sure we don't accidently deliver that signal to
+    // the parent process. If this happened, we'll close the pipes
+    // and create new ones immediately. This is safe to do inside
+    // the signal handler.
+    state->pid_ = pid;
+    signal_set_service::close_descriptors();
+    signal_set_service::open_descriptors();
+  }
   signed_size_type result = ::write(state->write_descriptor_,
       &signal_number, sizeof(signal_number));
   (void)result;
@@ -205,8 +231,17 @@ void signal_set_service::notify_fork(execution_context::fork_event fork_ev)
     if (state->fork_prepared_)
     {
       boost::asio::detail::signal_blocker blocker;
-      close_descriptors();
-      open_descriptors();
+      pid_t pid = ::getpid();
+      if (state->pid_ != pid)
+      {
+        // There is a small chance this was already done by a signal
+        // that was delivered between ::fork() and notify_fork(). If
+        // so, we don't want to re-open the pipe as we would lose that
+        // signal.
+        state->pid_ = pid;
+        close_descriptors();
+        open_descriptors();
+      }
       int read_descriptor = state->read_descriptor_;
       state->fork_prepared_ = false;
       lock.unlock();

--- a/include/boost/asio/detail/signal_set_service.hpp
+++ b/include/boost/asio/detail/signal_set_service.hpp
@@ -57,6 +57,8 @@ extern "C" BOOST_ASIO_DECL void boost_asio_signal_handler(int signal_number);
 class signal_set_service :
   public execution_context_service_base<signal_set_service>
 {
+  friend void boost_asio_signal_handler(int signal_number);
+
 public:
   // Type used for tracking an individual signal registration.
   class registration


### PR DESCRIPTION
If a child process received a signal right after fork()
but before notify_fork(fork_child) was called, the signal
is leaked to the parent process, causing it to believe it
received that signal instead of the child.

This is some sample code to reproduce the issue:
```
// Compile & run: g++ -pthread -o signal_fork_leak signal_fork_leak.cpp -lboost_system && ./signal_fork_leak
//
// Output with fix (expected):
//  child created, sending SIGUSR1 to child
//  child running
//  child received signal 10
//  sending SIGUSR2 to child
//  child received signal 12
//  child exiting
//  child exited with code 0
//
// Output without fix:
//  child created, sending SIGUSR1 to child
//  child running
//  sending SIGUSR2 to child
//  parent received signal 10
//  child received signal 12
//  child exiting
//  child exited with code 0

#include <sys/types.h>
#include <sys/wait.h>
#include <signal.h>
#include <boost/asio.hpp>
#include <iostream>

pid_t g_parent = ::getpid();

static void signal_handler(boost::asio::signal_set& signals, const boost::system::error_code& err, int signal_number)
{
	if (!err)
	{
		if (signal_number == SIGCHLD)
		{
			int status = 0;
			pid_t pid = ::waitpid(-1, &status, WNOHANG);
			if (pid > 0)
			{
				if (WIFEXITED(status))
				{
					std::cout << "child exited with code " << WEXITSTATUS(status) << std::endl;
					return;
				}
				else if (WIFSIGNALED(status))
				{
					std::cout << "child exited due to unhandled signal " << WTERMSIG(status) << std::endl;
					return;
				}
			}
		}
		else
		{
			if (g_parent == ::getpid())
				std::cout << "parent received signal " << signal_number << std::endl;
			else
				std::cout << "child received signal " << signal_number << std::endl;
		}
		signals.async_wait(std::bind(signal_handler, std::ref(signals), std::placeholders::_1, std::placeholders::_2));
	}
}

int main()
{
	boost::asio::io_context io;
	boost::asio::signal_set signals(io, SIGUSR1, SIGUSR2, SIGCHLD);
	boost::asio::steady_timer tmr(io);
	signals.async_wait(std::bind(signal_handler, std::ref(signals), std::placeholders::_1, std::placeholders::_2));
	boost::asio::post(io,
		[&]()
		{
			io.notify_fork(boost::asio::execution_context::fork_prepare);
			pid_t p = ::fork();
			if (p == -1)
			{
				int err = errno;
				std::cerr << "fork() failed with error " << err << std::endl;
			}
			else if (p == 0)
			{
				std::cout << "child running" << std::endl;
				
				// sleep for a second to simulate delay
				std::this_thread::sleep_for(std::chrono::seconds(1));
				
				io.notify_fork(boost::asio::execution_context::fork_child);
				tmr.expires_after(std::chrono::seconds(2));
				tmr.async_wait(
					[&](const boost::system::error_code& err)
					{
						if (!err)
						{
							std::cout << "child exiting" << std::endl;
							io.stop();
						}
					});
			}
			else
			{
				io.notify_fork(boost::asio::execution_context::fork_parent);
				std::cout << "child created, sending SIGUSR1 to child" << std::endl;
				if (::kill(p, SIGUSR1) == -1)
				{
					int err = errno;
					std::cerr << "kill() failed with error " << err << std::endl;
				}
				std::this_thread::sleep_for(std::chrono::seconds(2));
				std::cout << "sending SIGUSR2 to child" << std::endl;
				if (::kill(p, SIGUSR2) == -1)
				{
					int err = errno;
					std::cerr << "kill() failed with error " << err << std::endl;
				}
			}
		});
	io.run();
	return 0;
}
```
