### PR TITLE
Fix service_registry::do_use_service blocking forever if a service with the same key was created

### DIFF
--- a/include/boost/asio/detail/impl/service_registry.ipp
+++ b/include/boost/asio/detail/impl/service_registry.ipp
@@ -138,8 +138,17 @@ execution_context::service* service_registry::do_use_service(
   service = first_service_;
   while (service)
   {
-    if (keys_match(service->key_, key))
+    if (keys_match(service->key_, key)) {
+      // Manually unlock the mutex before service shutdown and destructor call
+      // to avoid long lock contention for services based on win_iocp_io_context
+      // that join a thread upon destruction
+      lock.unlock ();
+      // Shutdown the service before destroying it, for services based on
+      // win_iocp_io_context that .join in the destructor but do not request
+      // the thread to quit there
+      new_service.ptr_->shutdown ();
       return service;
+    }
     service = service->next_;
   }
 


### PR DESCRIPTION
The `service_registry::do_use_service` function can hang forever on Windows if a service with the same key was created and registered while the mutex was unlocked. If the service uses `win_iocp_io_context`, its destructor (implicitly called upon return, by destroying `new_service`) will `join()` the internal thread for IOCP handling, without requesting it to stop before. This will leave both threads to block forever, while the `mutex_` is still locked (`lock`s destructor may be called _after_ `new_service`s), which may cause further blockages in other threads. This PR aims to fix this by calling `shutdown()` on the thread before returning, and unlocking the mutex explicitly before that. Another solution would be to call `shutdown()` from within `win_iocp_io_context::~win_iocp_io_context()`.