### PR TITLE
read_some: fix examples

### DIFF
--- a/include/boost/asio/read_until.hpp
+++ b/include/boost/asio/read_until.hpp
@@ -115,7 +115,7 @@ struct is_match_condition
  * @par Example
  * To read data into a @c std::string until a newline is encountered:
  * @code std::string data;
- * std::string n = boost::asio::read_until(s,
+ * size_t n = boost::asio::read_until(s,
  *     boost::asio::dynamic_buffer(data), '\n');
  * std::string line = data.substr(0, n);
  * data.erase(0, n); @endcode
@@ -217,7 +217,7 @@ std::size_t read_until(SyncReadStream& s,
  * @par Example
  * To read data into a @c std::string until a CR-LF sequence is encountered:
  * @code std::string data;
- * std::string n = boost::asio::read_until(s,
+ * size_t n = boost::asio::read_until(s,
  *     boost::asio::dynamic_buffer(data), "\r\n");
  * std::string line = data.substr(0, n);
  * data.erase(0, n); @endcode
@@ -328,7 +328,7 @@ std::size_t read_until(SyncReadStream& s,
  * @par Example
  * To read data into a @c std::string until a CR-LF sequence is encountered:
  * @code std::string data;
- * std::string n = boost::asio::read_until(s,
+ * size_t n = boost::asio::read_until(s,
  *     boost::asio::dynamic_buffer(data), boost::regex("\r\n"));
  * std::string line = data.substr(0, n);
  * data.erase(0, n); @endcode
@@ -1056,7 +1056,7 @@ std::size_t read_until(SyncReadStream& s,
  * @par Example
  * To read data into a @c std::string until a newline is encountered:
  * @code std::string data;
- * std::string n = boost::asio::read_until(s,
+ * size_t n = boost::asio::read_until(s,
  *     boost::asio::dynamic_buffer(data), '\n');
  * std::string line = data.substr(0, n);
  * data.erase(0, n); @endcode
@@ -1154,7 +1154,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
  * @par Example
  * To read data into a @c std::string until a CR-LF sequence is encountered:
  * @code std::string data;
- * std::string n = boost::asio::read_until(s,
+ * size_t n = boost::asio::read_until(s,
  *     boost::asio::dynamic_buffer(data), "\r\n");
  * std::string line = data.substr(0, n);
  * data.erase(0, n); @endcode
@@ -1260,7 +1260,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
  * @par Example
  * To read data into a @c std::string until a CR-LF sequence is encountered:
  * @code std::string data;
- * std::string n = boost::asio::read_until(s,
+ * size_t n = boost::asio::read_until(s,
  *     boost::asio::dynamic_buffer(data), boost::regex("\r\n"));
  * std::string line = data.substr(0, n);
  * data.erase(0, n); @endcode


### PR DESCRIPTION
read_some returns the length not the result