### PR TITLE
Allow using libpthread on Windows

### DIFF
--- a/include/boost/asio/detail/thread.hpp
+++ b/include/boost/asio/detail/thread.hpp
@@ -19,6 +19,8 @@
 
 #if !defined(BOOST_ASIO_HAS_THREADS)
 # include <boost/asio/detail/null_thread.hpp>
+#elif defined(BOOST_ASIO_HAS_PTHREADS)
+# include <boost/asio/detail/posix_thread.hpp>
 #elif defined(BOOST_ASIO_WINDOWS)
 # if defined(UNDER_CE)
 #  include <boost/asio/detail/wince_thread.hpp>
@@ -27,8 +29,6 @@
 # else
 #  include <boost/asio/detail/win_thread.hpp>
 # endif
-#elif defined(BOOST_ASIO_HAS_PTHREADS)
-# include <boost/asio/detail/posix_thread.hpp>
 #elif defined(BOOST_ASIO_HAS_STD_THREAD)
 # include <boost/asio/detail/std_thread.hpp>
 #else
@@ -41,6 +41,8 @@ namespace detail {
 
 #if !defined(BOOST_ASIO_HAS_THREADS)
 typedef null_thread thread;
+#elif defined(BOOST_ASIO_HAS_PTHREADS)
+typedef posix_thread thread;
 #elif defined(BOOST_ASIO_WINDOWS)
 # if defined(UNDER_CE)
 typedef wince_thread thread;
@@ -49,8 +51,6 @@ typedef winapp_thread thread;
 # else
 typedef win_thread thread;
 # endif
-#elif defined(BOOST_ASIO_HAS_PTHREADS)
-typedef posix_thread thread;
 #elif defined(BOOST_ASIO_HAS_STD_THREAD)
 typedef std_thread thread;
 #endif


### PR DESCRIPTION
Allow using libpthread on Windows

In some cases, using libpthread on Windows is desired, for example
when porting software that's already using libpthread, avoiding mixing
the two libraries, which can be troublesome.

This change will allow using libthread when targetting Windows and
BOOST_ASIO_HAS_PTHREADS is set.

Related change: https://github.com/chriskohlhoff/asio/pull/566

This commit is currently cherry-picked when building Ceph for Windows: https://github.com/ceph/ceph/blob/master/win32_deps_build.sh#L128-L246 