### PR TITLE
Don't overwrite errno if socket() fails on macOS/FreeBSD

### DIFF
--- a/include/boost/asio/detail/impl/socket_ops.ipp
+++ b/include/boost/asio/detail/impl/socket_ops.ipp
@@ -1825,7 +1825,9 @@ socket_type socket(int af, int type, int protocol,
   return s;
 #elif defined(__MACH__) && defined(__APPLE__) || defined(__FreeBSD__)
   socket_type s = ::socket(af, type, protocol);
-  get_last_error(ec, s < 0);
+  get_last_error(ec, s == invalid_socket);
+  if (s == invalid_socket)
+    return s;
 
   int optval = 1;
   int result = ::setsockopt(s, SOL_SOCKET,


### PR DESCRIPTION
The unconditional call to setsockopt() even if socket() fails is breaking some of my unit tests for socket() errors because errno is overwritten with EBADF.

Fixes: 42b575ce2cca (Access errno only when on the error path.)

