### PR TITLE
For LibreSSL use accessors instead of reaching into SSL_CTX.

### DIFF
--- a/include/boost/asio/ssl/impl/context.ipp
+++ b/include/boost/asio/ssl/impl/context.ipp
@@ -397,9 +397,7 @@ context::~context()
 {
   if (handle_)
   {
-#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
-      && !defined(LIBRESSL_VERSION_NUMBER)) \
-    || defined(BOOST_ASIO_USE_WOLFSSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(BOOST_ASIO_USE_WOLFSSL)
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
     void* cb_userdata = handle_->default_passwd_callback_userdata;
@@ -410,9 +408,7 @@ context::~context()
         static_cast<detail::password_callback_base*>(
             cb_userdata);
       delete callback;
-#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
-      && !defined(LIBRESSL_VERSION_NUMBER)) \
-    || defined(BOOST_ASIO_USE_WOLFSSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(BOOST_ASIO_USE_WOLFSSL)
       ::SSL_CTX_set_default_passwd_cb_userdata(handle_, 0);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
       handle_->default_passwd_callback_userdata = 0;
@@ -759,9 +755,7 @@ BOOST_ASIO_SYNC_OP_VOID context::use_certificate_chain(
   bio_cleanup bio = { make_buffer_bio(chain) };
   if (bio.p)
   {
-#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
-      && !defined(LIBRESSL_VERSION_NUMBER)) \
-    || defined(BOOST_ASIO_USE_WOLFSSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(BOOST_ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -788,9 +782,7 @@ BOOST_ASIO_SYNC_OP_VOID context::use_certificate_chain(
       BOOST_ASIO_SYNC_OP_VOID_RETURN(ec);
     }
 
-#if ((OPENSSL_VERSION_NUMBER >= 0x10002000L) \
-      && !defined(LIBRESSL_VERSION_NUMBER)) \
-    || defined(BOOST_ASIO_USE_WOLFSSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) || defined(BOOST_ASIO_USE_WOLFSSL)
     ::SSL_CTX_clear_chain_certs(handle_);
 #else
     if (handle_->extra_certs)
@@ -867,9 +859,7 @@ BOOST_ASIO_SYNC_OP_VOID context::use_private_key(
 {
   ::ERR_clear_error();
 
-#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
-      && !defined(LIBRESSL_VERSION_NUMBER)) \
-    || defined(BOOST_ASIO_USE_WOLFSSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(BOOST_ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -936,9 +926,7 @@ BOOST_ASIO_SYNC_OP_VOID context::use_rsa_private_key(
 {
   ::ERR_clear_error();
 
-#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
-      && !defined(LIBRESSL_VERSION_NUMBER)) \
-    || defined(BOOST_ASIO_USE_WOLFSSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(BOOST_ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -1177,9 +1165,7 @@ int context::verify_callback_function(int preverified, X509_STORE_CTX* ctx)
 BOOST_ASIO_SYNC_OP_VOID context::do_set_password_callback(
     detail::password_callback_base* callback, boost::system::error_code& ec)
 {
-#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
-      && !defined(LIBRESSL_VERSION_NUMBER)) \
-    || defined(BOOST_ASIO_USE_WOLFSSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(BOOST_ASIO_USE_WOLFSSL)
   void* old_callback = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
   ::SSL_CTX_set_default_passwd_cb_userdata(handle_, callback);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)


### PR DESCRIPTION
Fixing build with LibreSSL. Patch from OpenBSD.