### PR TITLE
update prioritised_handlers to pop the handler before executing it

### DIFF
--- a/example/cpp03/invocation/prioritised_handlers.cpp
+++ b/example/cpp03/invocation/prioritised_handlers.cpp
@@ -28,8 +28,8 @@ public:
     while (!handlers_.empty())
     {
       queued_handler handler = handlers_.top();
-      handler.execute();
       handlers_.pop();
+      handler.execute();
     }
   }
 


### PR DESCRIPTION
the handler should be removed from the priority queue before it is executed to avoid removing the wrong handler in case it adds a new handler which ends up at the highest priority.