### PR TITLE
Use declval in is_legacy_connect_condition check

### DIFF
--- a/include/boost/asio/impl/connect.hpp
+++ b/include/boost/asio/impl/connect.hpp
@@ -26,6 +26,7 @@
 #include <boost/asio/detail/handler_type_requirements.hpp>
 #include <boost/asio/detail/non_const_lvalue.hpp>
 #include <boost/asio/detail/throw_error.hpp>
+#include <boost/asio/detail/type_traits.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/asio/post.hpp>
 
@@ -74,9 +75,9 @@ namespace detail
 
     static const bool value =
       sizeof(asio_connect_condition_check(
-        (*static_cast<legacy_connect_condition_helper<T, Iterator>*>(0))(
-          *static_cast<const boost::system::error_code*>(0),
-          *static_cast<const Iterator*>(0)))) != 1;
+        (declval<legacy_connect_condition_helper<T, Iterator>>())(
+          declval<const boost::system::error_code>(),
+          declval<const Iterator>()))) != 1;
   };
 
   template <typename ConnectCondition, typename Iterator>


### PR DESCRIPTION
gcc 11.2 w/ -O3 rejects:
```
error: 'this' pointer is null [-Werror=nonnull]
   77 |         (*static_cast<legacy_connect_condition_helper<T, Iterator>*>(0))(
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
   78 |           *static_cast<const boost::system::error_code*>(0),
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   79 |           *static_cast<const Iterator*>(0)))) != 1;
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The source code in this repository is generated from an upstream repository at https://github.com/chriskohlhoff/asio.

Please consider raising new pull requests at https://github.com/chriskohlhoff/asio/pulls.
