### PR TITLE
Use std::invoke_result with libcxx

### DIFF
--- a/include/boost/asio/detail/config.hpp
+++ b/include/boost/asio/detail/config.hpp
@@ -1196,7 +1196,11 @@
 #   if (_MSC_VER >= 1911 && _MSVC_LANG >= 201703)
 #    define BOOST_ASIO_HAS_STD_INVOKE_RESULT 1
 #   endif // (_MSC_VER >= 1911 && _MSVC_LANG >= 201703)
-#  endif // defined(BOOST_ASIO_MSVC)
+#  elif defined(BOOST_ASIO_HAS_CLANG_LIBCXX)
+#   if (_LIBCPP_VERSION >= 7000 && _LIBCPP_STD_VER > 14)
+#    define BOOST_ASIO_HAS_STD_INVOKE_RESULT 1
+#   endif // (_LIBCPP_VERSION > 6000 && _LIBCPP_STD_VER > 14)
+#  endif
 # endif // !defined(BOOST_ASIO_DISABLE_STD_INVOKE_RESULT)
 #endif // !defined(BOOST_ASIO_HAS_STD_INVOKE_RESULT)
 


### PR DESCRIPTION
std::result_of is removed in clang 13 libcxx in C++20 mode per https://github.com/llvm/llvm-project/commit/2ff5a56e1ab2a95c36d3c5d2bef7c585125718ae
std::invoke_result is available in libcxx since clang 7 given _LIBCPP_STD_VER > 14 (this is the form of the check in libcxx <type_traits>)

The source code in this repository is generated from an upstream repository at https://github.com/chriskohlhoff/asio.

Please consider raising new pull requests at https://github.com/chriskohlhoff/asio/pulls.
