### PR TITLE
Add dependency on Boost::align

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(boost_asio INTERFACE include)
 
 target_link_libraries(boost_asio
   INTERFACE
+    Boost::align
     Boost::array
     Boost::assert
     Boost::bind


### PR DESCRIPTION
it is required on Windows (from boost/asio/detail/memory.hpp), since MSVC doesn't have std::aligned_alloc

The source code in this repository is generated from an upstream repository at https://github.com/chriskohlhoff/asio.

Please consider raising new pull requests at https://github.com/chriskohlhoff/asio/pulls.
