### PR TITLE
Fix building socket_ops.ipp without SIOCATMARK

### DIFF
--- a/include/boost/asio/detail/impl/socket_ops.ipp
+++ b/include/boost/asio/detail/impl/socket_ops.ipp
@@ -642,7 +642,7 @@ bool sockatmark(socket_type s, boost::system::error_code& ec)
 # endif // defined(ENOTTY)
 #else // defined(SIOCATMARK)
   int value = ::sockatmark(s);
-  get_last_error(ec, result < 0);
+  get_last_error(ec, value < 0);
 #endif // defined(SIOCATMARK)
 
   return ec ? false : value != 0;


### PR DESCRIPTION
Failed to build asio for systems without SIOCATMARK defined because of invalid old-version usage of undefined result variable in sockatmark

The source code in this repository is generated from an upstream repository at https://github.com/chriskohlhoff/asio.

Please consider raising new pull requests at https://github.com/chriskohlhoff/asio/pulls.
