### PR TITLE
Fixed the multicast examples.

### DIFF
--- a/example/cpp03/multicast/receiver.cpp
+++ b/example/cpp03/multicast/receiver.cpp
@@ -24,15 +24,20 @@ public:
     : socket_(io_context)
   {
     // Create the socket so that multiple may be bound to the same address.
-    boost::asio::ip::udp::endpoint listen_endpoint(
-        listen_address, multicast_port);
+    boost::asio::ip::udp::endpoint listen_endpoint(((listen_address.is_v6())
+            ? boost::asio::ip::udp::v6() : boost::asio::ip::udp::v4()),
+        multicast_port);
     socket_.open(listen_endpoint.protocol());
     socket_.set_option(boost::asio::ip::udp::socket::reuse_address(true));
     socket_.bind(listen_endpoint);
 
     // Join the multicast group.
-    socket_.set_option(
-        boost::asio::ip::multicast::join_group(multicast_address));
+    if (listen_address.is_v6())
+        socket_.set_option(boost::asio::ip::multicast::join_group(
+            multicast_address.to_v6(), listen_address.to_v6().scope_id()));
+    else
+        socket_.set_option(boost::asio::ip::multicast::join_group(
+            multicast_address.to_v4(), listen_address.to_v4()));
 
     socket_.async_receive_from(
         boost::asio::buffer(data_, max_length), sender_endpoint_,
@@ -79,9 +84,16 @@ int main(int argc, char* argv[])
     }
 
     boost::asio::io_context io_context;
-    receiver r(io_context,
-        boost::asio::ip::make_address(argv[1]),
-        boost::asio::ip::make_address(argv[2]));
+    boost::asio::ip::address listen_address(boost::asio::ip::make_address(argv[1]));
+    boost::asio::ip::address multicast_address(boost::asio::ip::make_address(argv[2]));
+    if ((listen_address.is_v4() && !multicast_address.is_v4())
+      || (!listen_address.is_v4() && multicast_address.is_v4()))
+    {
+      std::cerr << "Error: both addresses have to be IPv4 or IPv6." << std::endl;
+      return 1;
+    }
+
+    receiver r(io_context, listen_address, multicast_address);
     io_context.run();
   }
   catch (std::exception& e)

--- a/example/cpp03/multicast/sender.cpp
+++ b/example/cpp03/multicast/sender.cpp
@@ -21,12 +21,18 @@ class sender
 {
 public:
   sender(boost::asio::io_context& io_context,
+      const boost::asio::ip::address& listen_address,
       const boost::asio::ip::address& multicast_address)
     : endpoint_(multicast_address, multicast_port),
       socket_(io_context, endpoint_.protocol()),
       timer_(io_context),
       message_count_(0)
   {
+    if (listen_address.is_v6())
+      socket_.set_option(boost::asio::ip::multicast::outbound_interface(listen_address.to_v6().scope_id()));
+    else
+      socket_.set_option(boost::asio::ip::multicast::outbound_interface(listen_address.to_v4()));
+
     std::ostringstream os;
     os << "Message " << message_count_++;
     message_ = os.str();
@@ -75,18 +81,27 @@ int main(int argc, char* argv[])
 {
   try
   {
-    if (argc != 2)
+    if (argc != 3)
     {
       std::cerr << "Usage: sender <multicast_address>\n";
       std::cerr << "  For IPv4, try:\n";
-      std::cerr << "    sender 239.255.0.1\n";
+      std::cerr << "    sender 0.0.0.0 239.255.0.1\n";
       std::cerr << "  For IPv6, try:\n";
-      std::cerr << "    sender ff31::8000:1234\n";
+      std::cerr << "    sender 0::0 ff31::8000:1234\n";
       return 1;
     }
 
     boost::asio::io_context io_context;
-    sender s(io_context, boost::asio::ip::make_address(argv[1]));
+    boost::asio::ip::address listen_address(boost::asio::ip::make_address(argv[1]));
+    boost::asio::ip::address multicast_address(boost::asio::ip::make_address(argv[2]));
+    if ((listen_address.is_v4() && !multicast_address.is_v4())
+      || (!listen_address.is_v4() && multicast_address.is_v4()))
+    {
+      std::cerr << "Error: both addresses have to be IPv4 or IPv6." << std::endl;
+      return 1;
+    }
+
+    sender s(io_context, listen_address, multicast_address);
     io_context.run();
   }
   catch (std::exception& e)


### PR DESCRIPTION
I couldn't find the source code for the examples in https://github.com/chriskohlhoff/asio/pulls , so I'm submitting this here.

The existing examples for multicast sender/receiver don't work.
I don't know if they ever worked.
But they're fixed now.
I tested these under MS Windows and Linux.
