### PR TITLE
Adding clang-14 coroutines support (second attempt)

### DIFF
--- a/include/boost/asio/detail/config.hpp
+++ b/include/boost/asio/detail/config.hpp
@@ -2054,7 +2054,11 @@
 #    endif // defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 #   endif // (_MSC_FULL_VER >= 190023506)
 #  elif defined(__clang__)
-#   if (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
+#   if (__cplusplus >= 202002) && (__cpp_coroutines >= 201703)
+#    if __has_include(<coroutine>)
+#     define BOOST_ASIO_HAS_CO_AWAIT 1
+#    endif // __has_include(<coroutine>)
+#   elif (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
 #    if __has_include(<experimental/coroutine>)
 #     define BOOST_ASIO_HAS_CO_AWAIT 1
 #    endif // __has_include(<experimental/coroutine>)
@@ -2076,8 +2080,13 @@
 #   if (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705)
 #    define BOOST_ASIO_HAS_STD_COROUTINE 1
 #   endif // (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705)
-#  endif // defined(BOOST_ASIO_MSVC)
-#  if defined(__GNUC__)
+#  elif defined(__clang__)
+#   if (__cplusplus >= 202002) && (__cpp_coroutines >= 201703)
+#    if __has_include(<coroutine>)
+#     define BOOST_ASIO_HAS_STD_COROUTINE 1
+#    endif // __has_include(<coroutine>)
+#   endif // (__cplusplus >= 202002) && (__cpp_coroutines >= 201703)
+#  elif defined(__GNUC__)
 #   if (__cplusplus >= 201709) && (__cpp_impl_coroutine >= 201902)
 #    if __has_include(<coroutine>)
 #     define BOOST_ASIO_HAS_STD_COROUTINE 1


### PR DESCRIPTION
In clang-14 ```<experimental/coroutine>``` is replaced by ```<coroutine>```, thus need to add an additional clang version test macro to set ```BOOST_ASIO_HAS_CO_AWAIT``` correctly.