### PR TITLE
Use BOOST_DEFAULTED_FUNCTION on empty destructors

### DIFF
--- a/include/boost/asio/ip/bad_address_cast.hpp
+++ b/include/boost/asio/ip/bad_address_cast.hpp
@@ -37,7 +37,7 @@ public:
   bad_address_cast() {}
 
   /// Destructor.
-  virtual ~bad_address_cast() BOOST_ASIO_NOEXCEPT_OR_NOTHROW {}
+  BOOST_DEFAULTED_FUNCTION(virtual ~bad_address_cast() BOOST_ASIO_NOEXCEPT_OR_NOTHROW, {})
 
   /// Get the message associated with the exception.
   virtual const char* what() const BOOST_ASIO_NOEXCEPT_OR_NOTHROW


### PR DESCRIPTION
The compiler-generated copy constructor and copy assignment operator are deprecated since C++11 on classes with user-declared destructors.

This change allows clean compilation with the -Wdeprecated-copy-dtor/-Wdeprecated-copy-with-user-provided-dtor flag.

The source code in this repository is generated from an upstream repository at https://github.com/chriskohlhoff/asio.

Please consider raising new pull requests at https://github.com/chriskohlhoff/asio/pulls.
