### PR TITLE
Implicitly link Threads::Threads with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ cmake_minimum_required(VERSION 3.5...3.16)
 
 project(boost_asio VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 add_library(boost_asio INTERFACE)
 add_library(Boost::asio ALIAS boost_asio)
 
@@ -30,6 +33,8 @@ target_link_libraries(boost_asio
     Boost::throw_exception
     Boost::type_traits
     Boost::utility
+
+    Threads::Threads
 )
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")


### PR DESCRIPTION
This PR adds the Threads::Threads library (which resolves to pthread on Linux and is empty on Windows) when targeting the interface library Boost::asio. Without it, using Boost::asio on Linux leads to undefined symbols, e.g.

set(Boost_ROOT <path_to_boost_install_dir>)
find_package(Boost COMPONENTS asio)
target_link_library(myexe Boost::asio)
