### PR TITLE
 The modifications remove unnecessary uses of std::move() for improve…

### DIFF
--- a/include/boost/asio/experimental/impl/promise.hpp
+++ b/include/boost/asio/experimental/impl/promise.hpp
@@ -64,12 +64,14 @@ struct promise_impl<void(Ts...), Executor, Allocator>
   Allocator allocator;
   Executor executor;
 
-  template<typename Func, std::size_t... Idx>
-  void apply_impl(Func f, boost::asio::detail::index_sequence<Idx...>)
-  {
-    auto& result_type = *reinterpret_cast<promise_impl::result_type*>(&result);
-    f(std::get<Idx>(std::move(result_type))...);
-  }
+ template<typename Func, std::size_t... Idx>
+void apply_impl(Func f, boost::asio::detail::index_sequence<Idx...>)
+{
+  auto& result_type = *reinterpret_cast<promise_impl::result_type*>(&result);
+  f(std::get<Idx>(result_type)...);  // Remove std::move()
+}
+
+
 
   using allocator_type = Allocator;
   allocator_type get_allocator() {return allocator;}
@@ -231,19 +233,20 @@ struct promise_handler<void(Ts...), Executor, Allocator>
     return promise<void(Ts...), executor_type, allocator_type>{impl_};
   }
 
-  void operator()(std::remove_reference_t<Ts>... ts)
-  {
-    assert(impl_);
+void operator()(std::remove_reference_t<Ts>... ts)
+{
+  assert(impl_);
 
-    using result_type = typename promise_impl<
-      void(Ts...), allocator_type, executor_type>::result_type ;
+  using result_type = typename promise_impl<
+    void(Ts...), allocator_type, executor_type>::result_type ;
 
-    new (&impl_->result) result_type(std::move(ts)...);
-    impl_->done = true;
+  new (&impl_->result) result_type(ts...);  // Remove std::move()
 
-    if (impl_->completion)
-      impl_->complete_with_result();
-  }
+  impl_->done = true;
+
+  if (impl_->completion)
+    impl_->complete_with_result();
+}
 };
 
 } // namespace detail


### PR DESCRIPTION
This pull request addresses two modifications in the `promise_impl` class within the `experimental/impl/promise.hpp` file:
that there is indeed an unnecessary use of std::move() in the apply_impl function. Specifically, the line f(std::get<Idx>(std::move(result_type))...); could be modified to remove the unnecessary std::move().

Here's the corrected version of the apply_impl function:
**template<typename Func, std::size_t... Idx>
void apply_impl(Func f, boost::asio::detail::index_sequence<Idx...>)
{
  auto& result_type = *reinterpret_cast<promise_impl::result_type*>(&result);
  f(std::get<Idx>(result_type)...);  // Remove std::move()
}**
and In the operator() function of the promise_handler class, the modification involves removing the unnecessary use of std::move() when storing the result values in the promise object. The line new (&impl_->result) result_type(ts...); initializes the result object by directly forwarding the ts arguments without using std::move().

This modification ensures that the result values are efficiently stored in the promise object without unnecessary moves.
void operator()(std::remove_reference_t<Ts>... ts)
**{
  assert(impl_);

  using result_type = typename promise_impl<
    void(Ts...), allocator_type, executor_type>::result_type ;

  new (&impl_->result) result_type(ts...);  // Remove std::move()

  impl_->done = true;

  if (impl_->completion)
    impl_->complete_with_result();
}**

**Certainly! Here's an explanation of the modifications made to the code**



