### PR TITLE
[winsock] Init to 2.2 instead of 2.0

### DIFF
--- a/include/boost/asio/detail/winsock_init.hpp
+++ b/include/boost/asio/detail/winsock_init.hpp
@@ -48,7 +48,7 @@ protected:
   BOOST_ASIO_DECL static void throw_on_error(data& d);
 };
 
-template <int Major = 2, int Minor = 0>
+template <int Major = 2, int Minor = 2>
 class winsock_init : private winsock_init_base
 {
 public:


### PR DESCRIPTION
The source code in this repository is generated from an upstream repository at https://github.com/chriskohlhoff/asio.

Please consider raising new pull requests at https://github.com/chriskohlhoff/asio/pulls.
