### PR TITLE
Fix type in namespace of ssl/stream example

### DIFF
--- a/include/boost/asio/ssl/stream.hpp
+++ b/include/boost/asio/ssl/stream.hpp
@@ -56,7 +56,7 @@ namespace ssl {
  * @code
  * boost::asio::io_context my_context;
  * boost::asio::ssl::context ctx(boost::asio::ssl::context::sslv23);
- * boost::asio::ssl::stream<asio:ip::tcp::socket> sock(my_context, ctx);
+ * boost::asio::ssl::stream<boost::asio::ip::tcp::socket> sock(my_context, ctx);
  * @endcode
  *
  * @par Concepts:


### PR DESCRIPTION
Fix a missing colon symbol as well as `boost::` in the asio/ssl/stream.hpp example.

Ps. I'm also not sure about the default context should that not be a client context (eg. `boost::asio::ssl::context::tlsv12_client`). But I digress...

The source code in this repository is generated from an upstream repository at https://github.com/chriskohlhoff/asio.

Please consider raising new pull requests at https://github.com/chriskohlhoff/asio/pulls.
