### PR TITLE
fix GCC Bug 57350: std::align missing

### DIFF
--- a/include/boost/asio/detail/memory.hpp
+++ b/include/boost/asio/detail/memory.hpp
@@ -55,7 +55,23 @@ inline const volatile T* to_address(const volatile T* p) { return p; }
 inline void* align(std::size_t alignment,
     std::size_t size, void*& ptr, std::size_t& space)
 {
+#if defined(__GNUC__) && __GNUC__ < 5
+  // copy from g++11.4.0
+  if (space < size)
+    return nullptr;
+  const auto __intptr = reinterpret_cast<uintptr_t>(ptr);
+  const auto __aligned = (__intptr - 1u + alignment) & -alignment;
+  const auto __diff = __aligned - __intptr;
+  if (__diff > (space - size))
+    return nullptr;
+  else
+  {
+    space -= __diff;
+    return ptr = reinterpret_cast<void *>(__aligned);
+  }
+#else
   return std::align(alignment, size, ptr, space);
+#endif
 }
 
 } // namespace detail


### PR DESCRIPTION
it will cause compilation failure if use g++<5.0. 
The detailed information of the bug can be found: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57350
is that possible to use macro to determine that when the compiler is gcc and the version is less than 5.0, use the source code （g++>=5.0) directly in the call to std::align to obtain asio library support for compilers before gcc 5.0?