### PR TITLE
Fix #456 resource leak in `awaitable::operator=`

### DIFF
--- a/include/boost/asio/awaitable.hpp
+++ b/include/boost/asio/awaitable.hpp
@@ -80,8 +80,11 @@ public:
   /// Move assignment.
   awaitable& operator=(awaitable&& other) noexcept
   {
-    if (this != &other)
+    if (this != &other) {
+      if (frame_)
+        frame_->destroy();
       frame_ = std::exchange(other.frame_, nullptr);
+    }
     return *this;
   }
 

--- a/include/boost/asio/awaitable.hpp
+++ b/include/boost/asio/awaitable.hpp
@@ -80,7 +80,8 @@ public:
   /// Move assignment.
   awaitable& operator=(awaitable&& other) noexcept
   {
-    if (this != &other) {
+    if (this != &other)
+    {
       if (frame_)
         frame_->destroy();
       frame_ = std::exchange(other.frame_, nullptr);


### PR DESCRIPTION
`awaitable::operator=` did not destroy the existing frame
