### PR TITLE
Fix QNX build by making signal flag restart conditional

### DIFF
--- a/include/boost/asio/detail/socket_types.hpp
+++ b/include/boost/asio/detail/socket_types.hpp
@@ -412,7 +412,9 @@ const int max_iov_len = IOV_MAX;
 // POSIX platforms are not required to define IOV_MAX.
 const int max_iov_len = 16;
 # endif
+# if defined(SA_RESTART)
 # define BOOST_ASIO_OS_DEF_SA_RESTART SA_RESTART
+# endif
 # define BOOST_ASIO_OS_DEF_SA_NOCLDSTOP SA_NOCLDSTOP
 # if defined(SA_NOCLDWAIT)
 #  define BOOST_ASIO_OS_DEF_SA_NOCLDWAIT SA_NOCLDWAIT

--- a/include/boost/asio/signal_set_base.hpp
+++ b/include/boost/asio/signal_set_base.hpp
@@ -63,7 +63,9 @@ public:
   enum class flags : int
   {
     none = 0,
+#if defined(SA_RESTART)
     restart = BOOST_ASIO_OS_DEF(SA_RESTART),
+#endif
     no_child_stop = BOOST_ASIO_OS_DEF(SA_NOCLDSTOP),
     no_child_wait = BOOST_ASIO_OS_DEF(SA_NOCLDWAIT),
     dont_care = -1


### PR DESCRIPTION
On QNX with compiler qcc 7.3 SA_RESTART does not exist.
