### PR TITLE
config: allow user to override BOOST_ASIO_DECL

### DIFF
--- a/include/boost/asio/detail/config.hpp
+++ b/include/boost/asio/detail/config.hpp
@@ -41,27 +41,29 @@
 # endif // !defined(BOOST_ASIO_SEPARATE_COMPILATION)
 #endif // !defined(BOOST_ASIO_HEADER_ONLY)
 
-#if defined(BOOST_ASIO_HEADER_ONLY)
-# define BOOST_ASIO_DECL inline
-#else // defined(BOOST_ASIO_HEADER_ONLY)
-# if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__CODEGEARC__)
+#if !defined(BOOST_ASIO_DECL)
+# if defined(BOOST_ASIO_HEADER_ONLY)
+#  define BOOST_ASIO_DECL inline
+# else // defined(BOOST_ASIO_HEADER_ONLY)
+#  if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__CODEGEARC__)
 // We need to import/export our code only if the user has specifically asked
 // for it by defining BOOST_ASIO_DYN_LINK.
-#  if defined(BOOST_ASIO_DYN_LINK)
+#   if defined(BOOST_ASIO_DYN_LINK)
 // Export if this is our own source, otherwise import.
-#   if defined(BOOST_ASIO_SOURCE)
-#    define BOOST_ASIO_DECL __declspec(dllexport)
-#   else // defined(BOOST_ASIO_SOURCE)
-#    define BOOST_ASIO_DECL __declspec(dllimport)
-#   endif // defined(BOOST_ASIO_SOURCE)
-#  endif // defined(BOOST_ASIO_DYN_LINK)
-# endif // defined(_MSC_VER) || defined(__BORLANDC__) || defined(__CODEGEARC__)
-#endif // defined(BOOST_ASIO_HEADER_ONLY)
+#    if defined(BOOST_ASIO_SOURCE)
+#     define BOOST_ASIO_DECL __declspec(dllexport)
+#    else // defined(BOOST_ASIO_SOURCE)
+#     define BOOST_ASIO_DECL __declspec(dllimport)
+#    endif // defined(BOOST_ASIO_SOURCE)
+#   endif // defined(BOOST_ASIO_DYN_LINK)
+#  endif // defined(_MSC_VER) || defined(__BORLANDC__) || defined(__CODEGEARC__)
+# endif // defined(BOOST_ASIO_HEADER_ONLY)
 
 // If BOOST_ASIO_DECL isn't defined yet define it now.
-#if !defined(BOOST_ASIO_DECL)
-# define BOOST_ASIO_DECL
-#endif // !defined(BOOST_ASIO_DECL)
+# if !defined(BOOST_ASIO_DECL)
+#  define BOOST_ASIO_DECL
+# endif // !defined(BOOST_ASIO_DECL)
+#endif
 
 // Helper macro for documentation.
 #define BOOST_ASIO_UNSPECIFIED(e) e


### PR DESCRIPTION
Currently, BOOST_ASIO_DECL is set by the library, with the logic:
- Header-only => inline
- Not header-only =>
	Win32?
		=> dllexport / dllimport.

In some cases it is important to have more control over this.
For instance:
 - To be able to set visibility attributes under ELF platform
 - To be able to disable visibility under DLL platform.

etc.
