### PR TITLE
Android: fix compile break with musl

### DIFF
--- a/include/boost/asio/detail/config.hpp
+++ b/include/boost/asio/detail/config.hpp
@@ -377,6 +377,10 @@
 #      if defined(__FreeBSD__) || defined(__Fuchsia__) || defined(__wasi__) \
          || defined(__NetBSD__) || defined(__OpenBSD__)
 #       define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1
+#      elif defined(__ANDROID__) 
+#       if (__ANDROID_API__ >= 28)
+#         define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1
+#       endif // (__ANDROID_API__ >= 28)
 #      elif defined(__linux__)
 #       if defined(_LIBCPP_HAS_MUSL_LIBC)
 #        define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1
@@ -385,8 +389,6 @@
 #         define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1
 #        endif // (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 17)
 #       endif // !defined(_LIBCPP_HAS_MUSL_LIBC)
-#      elif defined(__ANDROID__) && (__ANDROID_API__ >= 28)
-#       define BOOST_ASIO_HAS_STD_ALIGNED_ALLOC 1
 #      elif defined(__APPLE__)
 #       if defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
 #        if (__MAC_OS_X_VERSION_MIN_REQUIRED >= 101500)


### PR DESCRIPTION
Fix a compile break when building with _LIBCPP_HAS_MUSL_LIBC and an Android API older then 28

On Android both `__linux__` and `__ANDROID__` are defined. First check for `__ANDROID__` to get the correct behavior and not run into the Linux case

Compile break was introduced with
8b80ad7f2447cdbfc99f02a89a75d424dc8f9910

This commit is missing in the upstream repository at https://github.com/chriskohlhoff/asio. Therefore I opened this PR here.